### PR TITLE
[MIPS] Initial Registration of MIPS Architecture

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -480,7 +480,8 @@ if (is_fuchsia) {
   }
 }
 
-if (is_linux) {
+if (is_linux && target_cpu != "mipsel") {
+  #TODO: Handle MIPS.
   group("debian_package") {
     public_deps = [ "tools/debian_package" ]
   }

--- a/build/toolchain/linux/BUILD.gn
+++ b/build/toolchain/linux/BUILD.gn
@@ -15,6 +15,7 @@ declare_args() {
   arm64_toolchain_prefix = ""
   riscv32_toolchain_prefix = ""
   riscv64_toolchain_prefix = ""
+  mips_toolchain_prefix = ""
 }
 
 if (use_rbe) {
@@ -317,3 +318,23 @@ gcc_toolchain_suite("clang_riscv64") {
   toolchain_os = "linux"
   is_clang = true
 }
+
+gcc_toolchain_suite("mipsel") {
+  prefix = "mipsel-linux-gnu-"
+  if (mips_toolchain_prefix != "") {
+    prefix = mips_toolchain_prefix
+  }
+  cc = "${gcc_compiler_prefix}${prefix}gcc"
+  cxx = "${gcc_compiler_prefix}${prefix}g++"
+  asm = "${gcc_compiler_prefix}${prefix}gcc"
+  ar = "${prefix}ar"
+  ld = cxx
+  readelf = "${prefix}readelf"
+  nm = "${prefix}nm"
+  strip = "${prefix}strip"
+
+  toolchain_cpu = "mipsel"
+  toolchain_os = "linux"
+  is_clang = false
+}
+

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -176,6 +176,8 @@ config("dart_arch_config") {
     defines += [ "TARGET_ARCH_RISCV32" ]
   } else if (dart_target_arch == "riscv64") {
     defines += [ "TARGET_ARCH_RISCV64" ]
+  } else if (dart_target_arch == "mips") {
+    defines += [ "TARGET_ARCH_MIPS" ]
   } else {
     print("Invalid dart_target_arch: $dart_target_arch")
     assert(false)

--- a/runtime/bin/elf_loader.cc
+++ b/runtime/bin/elf_loader.cc
@@ -195,6 +195,9 @@ bool LoadedElf::ReadHeader() {
               "Architecture mismatch.");
 #elif defined(TARGET_ARCH_RISCV32) || defined(TARGET_ARCH_RISCV64)
   CHECK_ERROR(header_.machine == dart::elf::EM_RISCV, "Architecture mismatch.");
+#elif defined(TARGET_ARCH_MIPS)
+  // TODO: Handle MIPS.
+  UNIMPLEMENTED();
 #else
 #error Unsupported architecture architecture.
 #endif

--- a/runtime/platform/globals.h
+++ b/runtime/platform/globals.h
@@ -224,6 +224,9 @@ struct simd128_value_t {
 #else
 #error Unknown XLEN
 #endif
+#elif defined(__MIPSEL__)
+#define HOST_ARCH_MIPS 1
+#define ARCH_IS_32_BIT 1
 #else
 #error Architecture was not detected as supported by Dart.
 #endif
@@ -314,9 +317,12 @@ struct simd128_value_t {
 
 #if !defined(TARGET_ARCH_ARM) && !defined(TARGET_ARCH_X64) &&                  \
     !defined(TARGET_ARCH_IA32) && !defined(TARGET_ARCH_ARM64) &&               \
-    !defined(TARGET_ARCH_RISCV32) && !defined(TARGET_ARCH_RISCV64)
+    !defined(TARGET_ARCH_RISCV32) && !defined(TARGET_ARCH_RISCV64) &&          \
+    !defined(TARGET_ARCH_MIPS)
 // No target architecture specified pick the one matching the host architecture.
-#if defined(HOST_ARCH_ARM)
+#if defined(HOST_ARCH_MIPS)
+#define TARGET_ARCH_MIPS 1
+#elif defined(HOST_ARCH_ARM)
 #define TARGET_ARCH_ARM 1
 #elif defined(HOST_ARCH_X64)
 #define TARGET_ARCH_X64 1
@@ -334,7 +340,7 @@ struct simd128_value_t {
 #endif
 
 #if defined(TARGET_ARCH_IA32) || defined(TARGET_ARCH_ARM) ||                   \
-    defined(TARGET_ARCH_RISCV32)
+    defined(TARGET_ARCH_RISCV32) || defined(TARGET_ARCH_MIPS)
 #define TARGET_ARCH_IS_32_BIT 1
 #elif defined(TARGET_ARCH_X64) || defined(TARGET_ARCH_ARM64) ||                \
     defined(TARGET_ARCH_RISCV64)
@@ -355,7 +361,7 @@ struct simd128_value_t {
 #error Mismatched Host/Target architectures.
 #endif  // !defined(ARCH_IS_64_BIT) && !defined(FFI_UNIT_TESTS)
 #elif defined(TARGET_ARCH_IA32) || defined(TARGET_ARCH_ARM) ||                 \
-    defined(TARGET_ARCH_RISCV32)
+    defined(TARGET_ARCH_RISCV32) || defined(TARGET_ARCH_MIPS)
 #if defined(ARCH_IS_64_BIT) && defined(TARGET_ARCH_ARM)
 // This is simarm_x64 or simarm_arm64, which is the only case where host/target
 // architecture mismatch is allowed. Unless, we're running FFI unit tests.
@@ -391,6 +397,10 @@ struct simd128_value_t {
 #endif
 #elif defined(TARGET_ARCH_RISCV64)
 #if !defined(HOST_ARCH_RISCV64)
+#define DART_INCLUDE_SIMULATOR 1
+#endif
+#elif defined(TARGET_ARCH_MIPS)
+#if !defined(HOST_ARCH_MIPS)
 #define DART_INCLUDE_SIMULATOR 1
 #endif
 #else
@@ -760,6 +770,8 @@ DART_FORCE_INLINE D bit_copy(const S& source) {
 #define kHostArchitectureName "riscv32"
 #elif defined(HOST_ARCH_RISCV64)
 #define kHostArchitectureName "riscv64"
+#elif defined(HOST_ARCH_MIPS)
+#define kHostArchitectureName "mips"
 #elif defined(HOST_ARCH_X64)
 #define kHostArchitectureName "x64"
 #else
@@ -778,6 +790,8 @@ DART_FORCE_INLINE D bit_copy(const S& source) {
 #define kTargetArchitectureName "riscv64"
 #elif defined(TARGET_ARCH_X64)
 #define kTargetArchitectureName "x64"
+#elif defined(TARGET_ARCH_MIPS)
+#define kTargetArchitectureName "mips"
 #else
 #error Target architecture detection failed.
 #endif

--- a/runtime/vm/compiler/assembler/assembler.h
+++ b/runtime/vm/compiler/assembler/assembler.h
@@ -27,6 +27,8 @@
 #include "vm/compiler/assembler/assembler_arm64.h"
 #elif defined(TARGET_ARCH_RISCV32) || defined(TARGET_ARCH_RISCV64)
 #include "vm/compiler/assembler/assembler_riscv.h"
+#elif defined(TARGET_ARCH_MIPS)
+  // TODO: Handle MIPS.
 #else
 #error Unknown architecture.
 #endif

--- a/runtime/vm/constants.h
+++ b/runtime/vm/constants.h
@@ -15,6 +15,9 @@
 #include "vm/constants_arm64.h"
 #elif defined(TARGET_ARCH_RISCV32) || defined(TARGET_ARCH_RISCV64)
 #include "vm/constants_riscv.h"
+#elif defined(TARGET_ARCH_MIPS)
+  // TODO: Handle MIPS.
+  // UNIMPLEMENTED();
 #else
 #error Unknown architecture.
 #endif

--- a/runtime/vm/ffi_callback_metadata.h
+++ b/runtime/vm/ffi_callback_metadata.h
@@ -342,6 +342,8 @@ class FfiCallbackMetadata {
   static constexpr intptr_t kNativeCallbackTrampolineSize = 8;
   static constexpr intptr_t kNativeCallbackSharedStubSize = 302;
   static constexpr intptr_t kNativeCallbackTrampolineStackDelta = 2;
+#elif defined(TARGET_ARCH_MIPS)
+  // TODO: Handle MIPS.
 #else
 #error What architecture?
 #endif

--- a/runtime/vm/object.h
+++ b/runtime/vm/object.h
@@ -5852,6 +5852,8 @@ class Instructions : public Object {
   static constexpr intptr_t kPolymorphicEntryOffsetJIT = 44;
   static constexpr intptr_t kMonomorphicEntryOffsetAOT = 6;
   static constexpr intptr_t kPolymorphicEntryOffsetAOT = 18;
+#elif defined(TARGET_ARCH_MIPS)
+  // TODO: Handle MIPS.
 #else
 #error Missing entry offsets for current architecture
 #endif

--- a/runtime/vm/stack_frame.h
+++ b/runtime/vm/stack_frame.h
@@ -22,6 +22,8 @@
 #include "vm/stack_frame_arm64.h"
 #elif defined(TARGET_ARCH_RISCV32) || defined(TARGET_ARCH_RISCV64)
 #include "vm/stack_frame_riscv.h"
+#elif defined(TARGET_ARCH_MIPS)
+  // TODO: Handle MIPS.
 #else
 #error Unknown architecture.
 #endif

--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -875,7 +875,7 @@ group("create_full_sdk") {
   }
 
   if (dart_target_arch != "ia32" && dart_target_arch != "x86" &&
-      dart_target_arch != "arm") {
+      dart_target_arch != "arm" && dart_target_arch != "mips") {
     # Do not include gen_snapshot binaries for cross-compilation into
     # SDK, but add them as a dependency, so that they are built.
     public_deps += [

--- a/sdk/bin/dart
+++ b/sdk/bin/dart
@@ -30,7 +30,7 @@ then
   DIRS=$( ls "$OUT_DIR" )
   # list of possible configurations in decreasing desirability
   CONFIGS=("ReleaseX64" "ReleaseARM64" "ReleaseIA32" "DebugX64" "DebugIA32"
-    "ReleaseARM" "DebugARM" "DebugARM64" )
+    "ReleaseARM" "DebugARM" "DebugARM64" "ReleaseMIPS" "DebugMIPS")
   DART_CONFIGURATION="None"
   for CONFIG in ${CONFIGS[*]}
   do

--- a/tools/gn.py
+++ b/tools/gn.py
@@ -87,6 +87,8 @@ def HostCpuForArch(arch):
         candidates = ['riscv32', 'arm', 'x86', 'riscv64', 'arm64', 'x64']
     elif arch in ['riscv64', 'simriscv64']:
         candidates = ['riscv64', 'arm64', 'x64']
+    elif arch in ['mips']:
+        candidates = ['mips', 'x86']
     else:
         raise Exception("Unknown Dart architecture: %s" % arch)
 
@@ -115,6 +117,8 @@ def TargetCpuForArch(arch):
         return 'riscv32'
     elif arch.startswith('riscv64'):
         return 'riscv64'
+    elif arch.startswith('mips'):
+        return 'mipsel'
 
     # Simulators
     if arch.endswith('_x64'):
@@ -297,7 +301,7 @@ def ToGnArgs(args, mode, arch, target_os, sanitizer, verify_sdk_hash,
 
         toolchain = ToolchainPrefix(args)
         if toolchain:
-            for arch in ['ia32', 'x64', 'arm', 'arm64', 'riscv32', 'riscv64']:
+            for arch in ['ia32', 'x64', 'arm', 'arm64', 'riscv32', 'riscv64', 'mips']:
                 prefix = ParseStringMap(arch, toolchain)
                 if prefix != None:
                     gn_args[arch + '_toolchain_prefix'] = prefix
@@ -382,6 +386,7 @@ def ProcessOptions(args):
                     'x64c',
                     'arm64c',
                     'riscv64',
+                    'mips',
             ]:
                 print(
                     "Cross-compilation to %s is not supported for architecture %s."
@@ -393,7 +398,7 @@ def ProcessOptions(args):
                     "Cross-compilation to %s is not supported on host os %s." %
                     (os_name, HOST_OS))
                 return False
-            if not arch in ['x64', 'arm64', 'x64c', 'arm64c', 'riscv64']:
+            if not arch in ['x64', 'arm64', 'x64c', 'arm64c', 'riscv64', 'mips']:
                 print(
                     "Cross-compilation to %s is not supported for architecture %s."
                     % (os_name, arch))


### PR DESCRIPTION
This patch registers MIPS as a valid target architecture in the Dart SDK build system.
This change lays the groundwork for future MIPS platform support.