### PR TITLE
Refactor Condition from class to enum for ISA alignment

### DIFF
--- a/runtime/vm/compiler/assembler/assembler.h
+++ b/runtime/vm/compiler/assembler/assembler.h
@@ -38,27 +38,6 @@ namespace dart {
 // Convert comparison Token::Kind to GPR comparison condition.
 static inline Condition TokenKindToIntCondition(Token::Kind kind,
                                                 bool is_unsigned) {
-#if defined(TARGET_ARCH_MIPS)
-  switch (kind) {
-    case Token::kEQ:
-      return Condition::EQUAL;
-    case Token::kNE:
-      return Condition::NOT_EQUAL;
-    case Token::kLT:
-      return is_unsigned ? Condition::UNSIGNED_LESS : Condition::LESS;
-    case Token::kGT:
-      return is_unsigned ? Condition::UNSIGNED_GREATER : Condition::GREATER;
-    case Token::kLTE:
-      return is_unsigned ? Condition::UNSIGNED_LESS_EQUAL
-                         : Condition::LESS_EQUAL;
-    case Token::kGTE:
-      return is_unsigned ? Condition::UNSIGNED_GREATER_EQUAL
-                         : Condition::GREATER_EQUAL;
-    default:
-      UNREACHABLE();
-      return Condition::kInvalidCondition;
-  }
-#else
   // Use platform-independent condition names
   // declared in constant_<arch>.h on all platforms.
   switch (kind) {
@@ -78,7 +57,6 @@ static inline Condition TokenKindToIntCondition(Token::Kind kind,
       UNREACHABLE();
       return OVERFLOW;
   }
-#endif
 }
 
 }  // namespace dart

--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -1,0 +1,41 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#if defined(TARGET_ARCH_MIPS)
+
+namespace dart {
+namespace compiler{
+
+void Assembler::CompareRegisters(Register rn, Register rm) {
+  ASSERT(deferred_compare_ == kNone);
+  deferred_compare_ = kCompareReg;
+  deferred_left_ = rn;
+  deferred_reg_ = rm;
+}
+
+void Assembler::TestRegisters(Register rn, Register rm) {
+  ASSERT(deferred_compare_ == kNone);
+  deferred_compare_ = kTestReg;
+  deferred_left_ = rn;
+  deferred_reg_ = rm;
+}
+
+void Assembler::CompareImmediate(Register rn, int32_t imm, OperandSize sz) {
+  ASSERT(deferred_compare_ == kNone);
+  deferred_compare_ = kCompareImm;
+  deferred_left_ = rn;
+  deferred_imm_ = imm;
+}
+
+void Assembler::TestImmediate(Register rn, int32_t imm, OperandSize sz) {
+  ASSERT(deferred_compare_ == kNone);
+  deferred_compare_ = kTestImm;
+  deferred_left_ = rn;
+  deferred_imm_ = imm;
+}
+
+}  // namespace compiler
+}  // namespace dart
+
+#endif  // defined TARGET_ARCH_MIPS

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -99,6 +99,12 @@ class Assembler : public AssemblerBase {
           UNIMPLEMENTED();
   }
   ~Assembler() {}
+
+  void CompareImmediate(Register rn, int32_t imm, OperandSize sz = kWordBytes) override;
+  void TestImmediate(Register rn, int32_t imm, OperandSize sz = kWordBytes);
+
+  void CompareRegisters(Register rn, Register rm);
+  void TestRegisters(Register rn, Register rm);
   
  private:
   bool use_far_branches_;
@@ -106,6 +112,19 @@ class Assembler : public AssemblerBase {
   bool in_delay_slot_;
 
   bool constant_pool_allowed_;
+
+  enum DeferredCompareType {
+    kNone,
+    kCompareReg,
+    kCompareImm,
+    kTestReg,
+    kTestImm,
+  };
+  
+  DeferredCompareType deferred_compare_ = kNone;
+  Register deferred_left_ = kNoRegister;
+  Register deferred_reg_ = kNoRegister;
+  intptr_t deferred_imm_ = 0;
 
   void Emit(int32_t value) {
     // Emitting an instruction clears the delay slot state.

--- a/runtime/vm/compiler/compiler_sources.gni
+++ b/runtime/vm/compiler/compiler_sources.gni
@@ -29,6 +29,7 @@ compiler_sources = [
   "assembler/assembler_base.h",
   "assembler/assembler_ia32.cc",
   "assembler/assembler_ia32.h",
+  "assembler/assembler_mips.cc",
   "assembler/assembler_mips.h",
   "assembler/assembler_riscv.cc",
   "assembler/assembler_riscv.h",

--- a/runtime/vm/constants_mips.h
+++ b/runtime/vm/constants_mips.h
@@ -130,48 +130,45 @@ enum FRegister {
 const int kFpuRegisterSize = 8;
 typedef double fpu_register_t;
 
-// There is no dedicated status register on MIPS, but Condition values are used
-// and passed around by the intermediate language, so we need a Condition type.
-// We delay code generation of a comparison that would result in a traditional
-// condition code in the status register by keeping both register operands and
-// the relational operator between them as the Condition.
-class Condition : public ValueObject {
- public:
-  enum RelationOperator {
-    kNoCondition = -1,
-    AL = 0,    // always
-    NV = 1,    // never
-    EQ = 2,    // equal
-    NE = 3,    // not equal
-    GE = 4,    // greater equal
-    LT = 5,    // less than
-    GT = 6,    // greater than
-    LE = 7,    // less equal
-    UGT = 8,   // unsigned greater than
-    ULE = 9,   // unsigned less equal
-    UGE = 10,  // unsigned greater equal
-    ULT = 11,  // unsigned less than
-    kSpecialCondition = 12,
-    kNumberOfConditions = 13,
+// Architecture-independent parts of the compiler should use
+// compare-and-branch instead of condition codes.
+enum Condition {
+  kNoCondition = -1,
+  AL = 0,    // always
+  NV = 1,    // never
+  EQ = 2,    // equal
+  NE = 3,    // not equal
+  GE = 4,    // greater equal
+  LT = 5,    // less than
+  GT = 6,    // greater than
+  LE = 7,    // less equal
+  UGT = 8,   // unsigned greater than
+  ULE = 9,   // unsigned less equal
+  UGE = 10,  // unsigned greater equal
+  ULT = 11,  // unsigned less than
+  VS = 12,   // overflow
+  VC = 13,   // no overflow
+  kSpecialCondition = 14,
+  kNumberOfConditions = 15,
 
-    // Platform-independent variants declared for all platforms
-    EQUAL = EQ,
-    ZERO = EQUAL,
-    NOT_EQUAL = NE,
-    NOT_ZERO = NOT_EQUAL,
-    LESS = LT,
-    LESS_EQUAL = LE,
-    GREATER_EQUAL = GE,
-    GREATER = GT,
-    UNSIGNED_LESS = ULT,
-    UNSIGNED_LESS_EQUAL = ULE,
-    UNSIGNED_GREATER = UGT,
-    UNSIGNED_GREATER_EQUAL = UGE,
-
-    INVALID_RELATION = 13,
-    kInvalidCondition = INVALID_RELATION
-  };
-};   
+  // Platform-independent variants declared for all platforms
+  EQUAL = EQ,
+  ZERO = EQUAL,
+  NOT_EQUAL = NE,
+  NOT_ZERO = NOT_EQUAL,
+  LESS = LT,
+  LESS_EQUAL = LE,
+  GREATER_EQUAL = GE,
+  GREATER = GT,
+  UNSIGNED_LESS = ULT,
+  UNSIGNED_LESS_EQUAL = ULE,
+  UNSIGNED_GREATER = UGT,
+  UNSIGNED_GREATER_EQUAL = UGE,
+  OVERFLOW = VS,
+  NO_OVERFLOW = VC,
+  INVALID_RELATION = 16,
+  kInvalidCondition = INVALID_RELATION
+};
 
 // The double precision floating point registers are concatenated pairs of the
 // single precision registers, e.g. D0 is F1:F0, D1 is F3:F2, etc.. We only


### PR DESCRIPTION
### Summary

- Replaced the Condition class with an enum to avoid divergence in condition handling across ISAs. 
- Moved comparison logic to the Assembler class.
- Added methods to defer comparisons until instruction emission.

Files added:
- vm/compiler/assembler/assembler_mips.cc

Closes #6.