### PR TITLE
Add Label class for branch handling in assembler

### DIFF
--- a/runtime/vm/compiler/assembler/assembler_base.h
+++ b/runtime/vm/compiler/assembler/assembler_base.h
@@ -272,6 +272,47 @@ class Label : public ZoneAllocated {
   friend class MicroAssembler;
   DISALLOW_COPY_AND_ASSIGN(Label);
 };
+#elif defined(TARGET_ARCH_MIPS)
+class Label : public ValueObject {
+ public:
+  Label() : position_(0) {}
+
+  ~Label() {
+    // Assert if label is being destroyed with unresolved branches pending.
+    ASSERT(!IsLinked());
+  }
+
+  // Returns the position for bound and linked labels. Cannot be used
+  // for unused labels.
+  intptr_t Position() const {
+    ASSERT(!IsUnused());
+    return IsBound() ? -position_ - target::kWordSize : position_ - target::kWordSize;
+  }
+
+  bool IsBound() const { return position_ < 0; }
+  bool IsUnused() const { return position_ == 0; }
+  bool IsLinked() const { return position_ > 0; }
+
+ private:
+  intptr_t position_;
+
+  void Reinitialize() { position_ = 0; }
+
+  void BindTo(intptr_t position) {
+    ASSERT(!IsBound());
+    position_ = -position - target::kWordSize;
+    ASSERT(IsBound());
+  }
+
+  void LinkTo(intptr_t position) {
+    ASSERT(!IsBound());
+    position_ = position + target::kWordSize;
+    ASSERT(IsLinked());
+  }
+
+  friend class Assembler;
+  DISALLOW_COPY_AND_ASSIGN(Label);
+};
 #else
 class Label : public ZoneAllocated {
  public:

--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -49,6 +49,10 @@ void Assembler::TestImmediate(Register rn, int32_t imm, OperandSize sz) {
   deferred_imm_ = imm;
 }
 
+void Assembler::Bind(Label* label) {
+  UNIMPLEMENTED();
+}
+
 }  // namespace compiler
 }  // namespace dart
 

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -757,6 +757,8 @@ class Assembler : public AssemblerBase {
   void BranchUnsignedLessEqual(Register rd, const Immediate& imm, Label* l) {
     UNIMPLEMENTED();
   }
+
+  void Bind(Label* label) override;
   
  private:
   bool use_far_branches_;


### PR DESCRIPTION
**Summary**

This pull request introduces the Label class to support branch instruction handling in the MIPS assembler.

**Details**

The Label class is added to assembler_base.h and is designed to represent branch targets in the generated code. It tracks whether a label is unused, linked (referenced but not yet defined), or bound (its final position is known). This mechanism is essential for correctly resolving forward and backward branches during code emission.

The class provides internal methods for binding and linking labels (BindTo, LinkTo), querying their state (IsBound, IsLinked, IsUnused), and retrieving their final code position.

A placeholder Bind(Label* label) method has also been added to the Assembler class. This method will eventually be responsible for resolving label positions and patching any pending branches targeting that label. It is currently marked as UNIMPLEMENTED().
