### PR TITLE
Add class ID stubs, InvertCondition helper, and MIPS Cop1Sub enum

### DIFF
--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -53,6 +53,28 @@ void Assembler::Bind(Label* label) {
   UNIMPLEMENTED();
 }
 
+void Assembler::LoadClassId(Register result, Register object) {
+  UNIMPLEMENTED();
+}
+
+void Assembler::LoadClassById(Register result, Register class_id) {
+  UNIMPLEMENTED();
+}
+
+void Assembler::CompareClassId(Register object,
+                               intptr_t class_id,
+                               Register scratch) {
+  UNIMPLEMENTED();
+}
+
+void Assembler::LoadClassIdMayBeSmi(Register result, Register object) {
+  UNIMPLEMENTED();
+}
+
+void Assembler::LoadTaggedClassIdMayBeSmi(Register result, Register object) {
+  UNIMPLEMENTED();
+}
+
 }  // namespace compiler
 }  // namespace dart
 

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -759,6 +759,14 @@ class Assembler : public AssemblerBase {
   }
 
   void Bind(Label* label) override;
+
+  void LoadClassId(Register result, Register object);
+  void LoadClassById(Register result, Register class_id);
+  void CompareClassId(Register object,
+                    intptr_t class_id,
+                    Register scratch = kNoRegister);
+  void LoadClassIdMayBeSmi(Register result, Register object);
+  void LoadTaggedClassIdMayBeSmi(Register result, Register object);
   
  private:
   bool use_far_branches_;

--- a/runtime/vm/constants_mips.h
+++ b/runtime/vm/constants_mips.h
@@ -583,6 +583,12 @@ enum Cop1Function {
   COP1_C_ULE = 0x37,
 };
 
+enum Cop1Sub {
+  COP1_MF = 0,
+  COP1_MT = 4,
+  COP1_BC = 8,
+};
+
 enum Format {
   FMT_S = 16,
   FMT_D = 17,

--- a/runtime/vm/constants_mips.h
+++ b/runtime/vm/constants_mips.h
@@ -171,6 +171,20 @@ enum Condition {
   kInvalidCondition = INVALID_RELATION
 };
 
+static inline Condition InvertCondition(Condition c) {
+  COMPILE_ASSERT((EQ ^ NE) == 1);
+  COMPILE_ASSERT((UGE ^ ULT) == 1);
+  COMPILE_ASSERT((UGT ^ ULE) == 1);
+  COMPILE_ASSERT((GE ^ LT) == 1);
+  COMPILE_ASSERT((GT ^ LE) == 1);
+  COMPILE_ASSERT((AL ^ NV) == 1);
+  COMPILE_ASSERT((VS ^ VC) == 1);
+
+  ASSERT(c != AL);
+  ASSERT(c != kInvalidCondition);
+  return static_cast<Condition>(c ^ 1);
+}
+
 // The double precision floating point registers are concatenated pairs of the
 // single precision registers, e.g. D0 is F1:F0, D1 is F3:F2, etc.. We only
 // tell the architecture generic code about the double precision registers, then


### PR DESCRIPTION
### Summary

This PR introduces several foundational components to support MIPS instruction decoding and code generation.

### Details

- Adds unimplemented placeholders in the Assembler for loading and comparing class IDs, including Smi-aware variants.
- Introduces the InvertCondition() helper to compute the logical inverse of condition codes, with compile-time and runtime validation.
- Defines the Cop1Sub enum to represent sub-opcodes for MIPS Coprocessor 1 (FPU) operations (MF, MT, BC).