### PR TITLE
Add MIPS CPU feature detection

### DIFF
--- a/runtime/vm/cpu.h
+++ b/runtime/vm/cpu.h
@@ -32,6 +32,8 @@ class CPU : public AllStatic {
 #include "vm/cpu_arm64.h"
 #elif defined(TARGET_ARCH_RISCV32) || defined(TARGET_ARCH_RISCV64)
 #include "vm/cpu_riscv.h"
+#elif defined(TARGET_ARCH_MIPS)
+#include "vm/cpu_mips.h"
 #else
 #error Unknown architecture.
 #endif

--- a/runtime/vm/cpu_mips.cc
+++ b/runtime/vm/cpu_mips.cc
@@ -1,0 +1,75 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#include "vm/globals.h"
+#if defined(TARGET_ARCH_MIPS)
+
+#include "vm/cpu.h"
+#include "vm/cpu_mips.h"
+
+#include "vm/cpuinfo.h"
+
+namespace dart {
+
+const char* HostCPUFeatures::hardware_ = nullptr;
+MIPSVersion HostCPUFeatures::mips_version_ = MIPSvUnknown;
+#if defined(DEBUG)
+bool HostCPUFeatures::initialized_ = false;
+#endif
+
+#if !defined(DART_INCLUDE_SIMULATOR)
+void HostCPUFeatures::Init() {
+  CpuInfo::Init();
+  hardware_ = CpuInfo::GetCpuModel();
+
+// We want to know the ISA version, but on MIPS, CpuInfo can't tell us, so
+// we use the same ISA version that Dart's C++ compiler targeted.
+#if defined(_MIPS_ARCH_MIPS32R2)
+  mips_version_ = MIPS32r2;
+#elif defined(_MIPS_ARCH_MIPS32)
+  mips_version_ = MIPS32;
+#endif
+
+#if defined(DEBUG)
+  initialized_ = true;
+#endif
+}
+
+void HostCPUFeatures::Cleanup() {
+  DEBUG_ASSERT(initialized_);
+#if defined(DEBUG)
+  initialized_ = false;
+#endif
+  ASSERT(hardware_ != nullptr);
+  free(const_cast<char*>(hardware_));
+  hardware_ = nullptr;
+  CpuInfo::Cleanup();
+}
+
+#else // !defined(DART_INCLUDE_SIMULATOR)
+
+void HostCPUFeatures::Init() {
+  CpuInfo::Init();
+  hardware_ = CpuInfo::GetCpuModel();
+  mips_version_ = MIPS32r2;
+#if defined(DEBUG)
+  initialized_ = true;
+#endif
+}
+
+void HostCPUFeatures::Cleanup() {
+  DEBUG_ASSERT(initialized_);
+#if defined(DEBUG)
+  initialized_ = false;
+#endif
+  ASSERT(hardware_ != nullptr);
+  free(const_cast<char*>(hardware_));
+  hardware_ = nullptr;
+  CpuInfo::Cleanup();
+}
+#endif // !defined(DART_INCLUDE_SIMULATOR)
+
+}  // namespace dart
+
+#endif  // defined TARGET_ARCH_MIPS

--- a/runtime/vm/cpu_mips.h
+++ b/runtime/vm/cpu_mips.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#ifndef RUNTIME_VM_CPU_MIPS_H_
+#define RUNTIME_VM_CPU_MIPS_H_
+
+#include "vm/allocation.h"
+
+namespace dart {
+
+// TargetCPUFeatures gives CPU features for the architecture that we are
+// generating code for. HostCPUFeatures gives the CPU features for the
+// architecture that we are actually running on. When the architectures
+// are the same, TargetCPUFeatures will query HostCPUFeatures. When they are
+// different (i.e. we are running in a simulator), HostCPUFeatures will
+// additionally mock the options needed for the target architecture so that
+// they may be altered for testing.
+
+enum MIPSVersion {
+  MIPS32,
+  MIPS32r2,
+  MIPSvUnknown,
+};
+
+class HostCPUFeatures : public AllStatic {
+ public:
+  static void Init();
+  static void Cleanup();
+  static const char* hardware() {
+    DEBUG_ASSERT(initialized_);
+    return hardware_;
+  }
+  static MIPSVersion mips_version() {
+    DEBUG_ASSERT(initialized_);
+    return mips_version_;
+  }
+
+ private:
+  static const char* hardware_;
+  static MIPSVersion mips_version_;
+#if defined(DEBUG)
+  static bool initialized_;
+#endif
+};
+
+class TargetCPUFeatures : public AllStatic {
+ public:
+  static void Init() { HostCPUFeatures::Init(); }
+  static void Cleanup() { HostCPUFeatures::Cleanup(); }
+  static const char* hardware() { return HostCPUFeatures::hardware(); }
+  static bool double_truncate_round_supported() { return false; }
+  static MIPSVersion mips_version() { return HostCPUFeatures::mips_version(); }
+};
+
+}  // namespace dart
+
+#endif  // RUNTIME_VM_CPU_MIPS_H_

--- a/runtime/vm/vm_sources.gni
+++ b/runtime/vm/vm_sources.gni
@@ -65,6 +65,7 @@ vm_sources = [
   "cpu_arm.cc",
   "cpu_arm64.cc",
   "cpu_ia32.cc",
+  "cpu_mips.cc",
   "cpu_riscv.cc",
   "cpu_x64.cc",
   "cpuid.cc",


### PR DESCRIPTION
### Summary
This PR introduces HostCPUFeatures and TargetCPUFeatures support for MIPS to enable basic hardware identification and ISA version querying.

### Details
- Handles both simulator and non-simulator builds.
- Adds initialization and cleanup logic.

**Files added:**
- runtime/vm/cpu_mips.h
- runtime/vm/cpu_mips.cc