### PR TITLE
Adds MIPS stack frame layout definition

### DIFF
--- a/runtime/vm/stack_frame.h
+++ b/runtime/vm/stack_frame.h
@@ -23,7 +23,7 @@
 #elif defined(TARGET_ARCH_RISCV32) || defined(TARGET_ARCH_RISCV64)
 #include "vm/stack_frame_riscv.h"
 #elif defined(TARGET_ARCH_MIPS)
-  // TODO: Handle MIPS.
+#include "vm/stack_frame_mips.h"
 #else
 #error Unknown architecture.
 #endif

--- a/runtime/vm/stack_frame_mips.h
+++ b/runtime/vm/stack_frame_mips.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#ifndef RUNTIME_VM_STACK_FRAME_MIPS_H_
+#define RUNTIME_VM_STACK_FRAME_MIPS_H_
+
+namespace dart {
+
+/* MIPS Dart Frame Layout
+
+               |                    | <- TOS
+Callee frame   | ...                |
+               | current RA         |    (PC of current frame)
+               | callee's PC marker |
+               +--------------------+
+Current frame  | ...               T| <- SP of current frame
+               | first local       T|
+               | caller's PP       T|
+               | CODE_REG          T|    (current frame's code object)
+               | caller's FP        | <- FP of current frame
+               | caller's RA        |    (PC of caller frame)
+               +--------------------+
+Caller frame   | last parameter     | <- SP of caller frame
+               |  ...               |
+
+               T against a slot indicates it needs to be traversed during GC.
+*/
+
+static constexpr int kDartFrameFixedSize = 4;  // PP, FP, RA, PC marker.
+static constexpr int kSavedPcSlotFromSp = -1;
+
+static constexpr int kFirstObjectSlotFromFp = -1;  // Used by GC to traverse stack.
+static constexpr int kLastFixedObjectSlotFromFp = -2;
+
+static constexpr int kFirstLocalSlotFromFp = -3;
+static constexpr int kSavedCallerPpSlotFromFp = -2;
+static constexpr int kPcMarkerSlotFromFp = -1;
+static constexpr int kSavedCallerFpSlotFromFp = 0;
+static constexpr int kSavedCallerPcSlotFromFp = 1;
+static constexpr int kParamEndSlotFromFp = 1;  // One slot past last parameter.
+static constexpr int kCallerSpSlotFromFp = 2;
+static constexpr int kLastParamSlotFromEntrySp = 0;
+
+}  // namespace dart
+
+#endif  // RUNTIME_VM_STACK_FRAME_MIPS_H_

--- a/runtime/vm/vm_sources.gni
+++ b/runtime/vm/vm_sources.gni
@@ -307,6 +307,7 @@ vm_sources = [
   "stack_frame_arm64.h",
   "stack_frame_ia32.h",
   "stack_frame_kbc.h",
+  "stack_frame_mips.h",
   "stack_frame_x64.h",
   "stack_trace.cc",
   "stack_trace.h",


### PR DESCRIPTION
**Summary**

This PR introduces header file stack_frame_mips.h which defines the stack layout for the MIPS architecture in Dart VM. It contains constants related to data positioning on the stack relative to FP and SP.

**Files added:**

* runtime/vm/stack_frame_mips.h


