### PR TITLE
Add MIPS CPU info, ICache flush, and ID support

### DIFF
--- a/runtime/vm/cpu_mips.cc
+++ b/runtime/vm/cpu_mips.cc
@@ -10,7 +10,41 @@
 
 #include "vm/cpuinfo.h"
 
+#if !defined(DART_INCLUDE_SIMULATOR)
+#include <asm/cachectl.h> /* NOLINT */
+#include <sys/syscall.h>  /* NOLINT */
+#include <unistd.h>       /* NOLINT */
+#endif
+
 namespace dart {
+
+void CPU::FlushICache(uword start, uword size) {
+#if defined(DART_PRECOMPILED_RUNTIME)
+  UNREACHABLE();
+#elif !defined(DART_INCLUDE_SIMULATOR)
+  // Nothing to do. Flushing no instructions.
+  if (size == 0) {
+    return;
+  }
+
+#if defined(DART_HOST_OS_LINUX)
+  char* beg = reinterpret_cast<char*>(start);
+  char* end = reinterpret_cast<char*>(start + size);
+  __builtin___clear_cache(beg, end);
+#else
+#error FlushICache only tested/supported on Linux
+#endif
+
+#endif
+}
+
+const char* CPU::Id() {
+  return
+#if defined(DART_INCLUDE_SIMULATOR)
+      "sim"
+#endif  // !defined(DART_INCLUDE_SIMULATOR)
+      "mips";
+}
 
 const char* HostCPUFeatures::hardware_ = nullptr;
 MIPSVersion HostCPUFeatures::mips_version_ = MIPSvUnknown;

--- a/runtime/vm/cpuinfo_linux.cc
+++ b/runtime/vm/cpuinfo_linux.cc
@@ -49,6 +49,14 @@ void CpuInfo::Init() {
   // We only rely on the base Linux configuration of IMAFDC, so don't need
   // dynamic feature detection.
   method_ = kCpuInfoNone;
+#elif defined(HOST_ARCH_MIPS)
+  fields_[kCpuInfoProcessor] = "system type";
+  fields_[kCpuInfoModel] = "cpu model";
+  fields_[kCpuInfoHardware] = "cpu model";
+  fields_[kCpuInfoFeatures] = "ASEs implemented";
+  fields_[kCpuInfoArchitecture] = "CPU architecture";
+  method_ = kCpuInfoSystem;
+  ProcCpuInfo::Init();
 #else
 #error Unrecognized target architecture
 #endif


### PR DESCRIPTION
### Details

- Added MIPS-specific CPU info fields.
- Implemented ICache flush using syscall when not in simulator mode.
- Implemented CPU::Id() to return "mips" or "sim" based on the build.