### PR TITLE
Add push/pop helpers for registers and values

### DIFF
--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -5,6 +5,7 @@
 #if defined(TARGET_ARCH_MIPS)
 
 #include "vm/compiler/assembler/assembler.h"
+#include "vm/compiler/backend/locations.h"
 
 namespace dart {
 namespace compiler{
@@ -19,6 +20,49 @@ void Assembler::EmitRegImmBranch(RtRegImm b, Register rs, Label* label) {
 
 void Assembler::EmitFpuBranch(bool kind, Label* label) {
   UNIMPLEMENTED();
+}
+
+void Assembler::PushRegisters(const RegisterSet& registers) {
+  UNIMPLEMENTED();
+}
+
+void Assembler::PopRegisters(const RegisterSet& registers) {
+  UNIMPLEMENTED();
+}
+
+void Assembler::PushRegistersInOrder(std::initializer_list<Register> regs) {
+  for (Register reg : regs) {
+    PushRegister(reg);
+  }
+}
+
+void PushRegisterPair(Register r0, Register r1){
+  ASSERT(r0 != SP);
+  ASSERT(r1 != SP);
+
+  addiu(SP, SP, Immediate(-2 * target::kWordSize));
+  sw(r1, Address(SP, target::kWordSize));
+  sw(r0, Address(SP, 0));
+}
+
+void PopRegisterPair(Register r0, Register r1){
+  ASSERT(r0 != SP);
+  ASSERT(r1 != SP);
+
+  lw(r1, Address(SP, target::kWordSize));
+  lw(r0, Address(SP, 0));
+  addiu(SP, SP, Immediate(2 * target::kWordSize));
+}
+
+void PushImmediate(int64_t immediate){
+  LoadImmediate(TMP, immediate);
+  Push(TMP);
+}
+
+void PushValueAtOffset(Register base, int32_t offset){
+  addiu(SP, SP, Immediate(-target::kWordSize));
+  lw(TMP, Address(base, offset));
+  sw(TMP, Address(SP, 0));
 }
 
 void Assembler::CompareRegisters(Register rn, Register rm) {

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -5,6 +5,7 @@
 #ifndef RUNTIME_VM_ASSEMBLER_MIPS_H_
 #define RUNTIME_VM_ASSEMBLER_MIPS_H_
 
+#include "platform/assert.h"
 #include "vm/compiler/assembler/assembler_base.h"
 #include "vm/constants.h"
 
@@ -20,6 +21,8 @@
 //   https://s3-eu-west-1.amazonaws.com/downloads-mips/documents/MD00086-2B-MIPS32BIS-AFP-6.06.pdf
 namespace dart {
 namespace compiler {
+
+class RegisterSet;
 
 class Immediate : public ValueObject {
  public:
@@ -99,6 +102,33 @@ class Assembler : public AssemblerBase {
           UNIMPLEMENTED();
   }
   ~Assembler() {}
+
+  void PushRegister(Register r) { Push(r); }
+  void PopRegister(Register r) { Pop(r); }
+
+  void PushRegisters(const RegisterSet& registers);
+  void PopRegisters(const RegisterSet& registers);
+
+  void PushRegistersInOrder(std::initializer_list<Register> regs);
+
+  void PushRegisterPair(Register r0, Register r1);
+  void PopRegisterPair(Register r0, Register r1);
+
+  void PushImmediate(int64_t immediate);
+
+  void PushValueAtOffset(Register base, int32_t offset);
+
+  void Push(Register rt) {
+    ASSERT(!in_delay_slot_);
+    addiu(SP, SP, Immediate(-target::kWordSize));
+    sw(rt, Address(SP));
+  }
+
+  void Pop(Register rt) {
+    ASSERT(!in_delay_slot_);
+    lw(rt, Address(SP));
+    addiu(SP, SP, Immediate(target::kWordSize));
+  }
 
   void CompareImmediate(Register rn, int32_t imm, OperandSize sz = kWordBytes) override;
   void TestImmediate(Register rn, int32_t imm, OperandSize sz = kWordBytes);


### PR DESCRIPTION
### Summary
This PR introduces a set of helper methods for pushing and popping single registers, register sets, register pairs, immediate values, and values at specific memory offsets. These utilities abstract common stack operations.