### PR TITLE
Add MIPS frame management support to the Assembler

### DIFF
--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -119,6 +119,105 @@ void Assembler::LoadTaggedClassIdMayBeSmi(Register result, Register object) {
   UNIMPLEMENTED();
 }
 
+void Assembler::EnterFrame(intptr_t frame_size) {
+  ASSERT(!in_delay_slot_);
+  addiu(SP, SP, Immediate(-2 * target::kWordSize));
+  sw(RA, Address(SP, 1 * target::kWordSize));
+  sw(FP, Address(SP, 0 * target::kWordSize));
+  mov(FP, SP);
+  if (frame_size != 0) {
+    addiu(SP, SP, Immediate(-frame_size));
+  }
+}
+
+void Assembler::LeaveFrame() {
+  ASSERT(!in_delay_slot_);
+  mov(SP, FP);
+  lw(RA, Address(SP, 1 * target::kWordSize));
+  lw(FP, Address(SP, 0 * target::kWordSize));
+  addiu(SP, SP, Immediate(2 * target::kWordSize));
+}
+
+void Assembler::LeaveFrameAndReturn() {
+  ASSERT(!in_delay_slot_);
+  mov(SP, FP);
+  lw(RA, Address(SP, 1 * target::kWordSize));
+  lw(FP, Address(SP, 0 * target::kWordSize));
+  Ret();
+  delay_slot()->addiu(SP, SP, Immediate(2 * target::kWordSize));
+}
+
+void Assembler::EnterStubFrame(intptr_t frame_size) {
+  EnterDartFrame(frame_size);
+}
+
+void Assembler::LeaveStubFrame() {
+  LeaveDartFrame();
+}
+
+void Assembler::LeaveStubFrameAndReturn(Register ra) {
+  LeaveDartFrameAndReturn(ra);
+}
+
+void Assembler::EnterDartFrame(intptr_t frame_size, bool load_pool_pointer) {
+  ASSERT(!in_delay_slot_);
+
+  SetPrologueOffset();
+
+  if (FLAG_precompiled_mode) {
+    addiu(SP, SP, Immediate(-2 * target::kWordSize));
+    sw(RA, Address(SP, 1 * target::kWordSize));
+    sw(FP, Address(SP, 0 * target::kWordSize));
+    mov(FP, SP);
+  } else {
+    addiu(SP, SP, Immediate(-4 * target::kWordSize));
+    sw(RA, Address(SP, 3 * target::kWordSize));
+    sw(FP, Address(SP, 2 * target::kWordSize));
+    sw(CODE_REG, Address(SP, 1 * target::kWordSize));
+    sw(PP, Address(SP, 0 * target::kWordSize));
+
+    // Set FP to the saved previous FP.
+    addiu(FP, SP, Immediate(2 * target::kWordSize));
+
+    if (load_pool_pointer) LoadPoolPointer();
+  }
+  set_constant_pool_allowed(true);
+
+  // Reserve space for locals.
+  AddImmediate(SP, -frame_size);
+}
+
+void Assembler::LeaveDartFrame(RestorePP restore_pp) {
+  ASSERT(!in_delay_slot_);
+  addiu(SP, FP, Immediate(-2 * target::kWordSize));
+
+  lw(RA, Address(SP, 3 * target::kWordSize));
+  lw(FP, Address(SP, 2 * target::kWordSize));
+  if (restore_pp == kRestoreCallerPP && !FLAG_precompiled_mode) {
+    lw(PP, Address(SP, 0 * target::kWordSize));
+  }
+  set_constant_pool_allowed(false);
+
+  // Adjust SP for PC, RA, FP, PP pushed in EnterDartFrame.
+  addiu(SP, SP, Immediate(4 * target::kWordSize));
+}
+
+void Assembler::LeaveDartFrameAndReturn(Register ra) {
+  ASSERT(!in_delay_slot_);
+  addiu(SP, FP, Immediate(-2 * target::kWordSize));
+
+  lw(RA, Address(SP, 3 * target::kWordSize));
+  lw(FP, Address(SP, 2 * target::kWordSize));
+  if (!FLAG_precompiled_mode) {
+    lw(PP, Address(SP, 0 * target::kWordSize));
+  }
+  set_constant_pool_allowed(false);
+
+  // Adjust SP for PC, RA, FP, PP pushed in EnterDartFrame, and return.
+  addiu(SP, SP, Immediate(4 * target::kWordSize));
+  jr(ra);
+}
+
 }  // namespace compiler
 }  // namespace dart
 

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -797,6 +797,9 @@ class Assembler : public AssemblerBase {
                     Register scratch = kNoRegister);
   void LoadClassIdMayBeSmi(Register result, Register object);
   void LoadTaggedClassIdMayBeSmi(Register result, Register object);
+
+  bool constant_pool_allowed() const { return constant_pool_allowed_; }
+  void set_constant_pool_allowed(bool b) { constant_pool_allowed_ = b; }
   
  private:
   bool use_far_branches_;

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -806,6 +806,26 @@ class Assembler : public AssemblerBase {
       prologue_offset_ = CodeSize();
     }
   }
+
+  void EnterFrame(intptr_t frame_size = 0);
+  void LeaveFrame();
+  void LeaveFrameAndReturn();
+
+  // Set up a stub frame so that the stack traversal code can easily identify
+  // a stub frame.
+  void EnterStubFrame(intptr_t frame_size = 0);
+  void LeaveStubFrame();
+  // A separate macro for when a Ret immediately follows, so that we can use
+  // the branch delay slot.
+  void LeaveStubFrameAndReturn(Register ra = RA);
+
+  // Set up a Dart frame on entry with a frame pointer and PC information to
+  // enable easy access to the RawInstruction object of code corresponding
+  // to this frame.
+  enum RestorePP { kRestoreCallerPP, kKeepCalleePP };
+  void EnterDartFrame(intptr_t frame_size, bool load_pool_pointer = true);
+  void LeaveDartFrame(RestorePP restore_pp = kRestoreCallerPP);
+  void LeaveDartFrameAndReturn(Register ra = RA);
   
  private:
   bool use_far_branches_;

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -800,6 +800,12 @@ class Assembler : public AssemblerBase {
 
   bool constant_pool_allowed() const { return constant_pool_allowed_; }
   void set_constant_pool_allowed(bool b) { constant_pool_allowed_ = b; }
+
+  void SetPrologueOffset() {
+    if (prologue_offset_ == -1) {
+      prologue_offset_ = CodeSize();
+    }
+  }
   
  private:
   bool use_far_branches_;


### PR DESCRIPTION
### Description:

This change adds frame setup and teardown support for the MIPS backend in the Dart SDK assembler. It introduces standard, stub, and Dart-specific frame routines, along with helpers for prologue handling and constant pool state.

#### The following functionality is added:

1. Standard frame routines:
- EnterFrame(intptr_t frame_size)
- LeaveFrame()
- LeaveFrameAndReturn()

These functions manage the setup and teardown of standard stack frames, including saving and restoring RA and FP, adjusting SP, and optionally reserving space for local variables

2. Stub frame routines:
- EnterStubFrame(intptr_t frame_size)
- LeaveStubFrame()
- LeaveStubFrameAndReturn(Register ra)

These functions do the same thing as the functions listed above.

3. Dart frame routines:
- EnterDartFrame(intptr_t frame_size, bool load_pool_pointer)
- LeaveDartFrame(RestorePP restore_pp)
- LeaveDartFrameAndReturn(Register ra)

These functions save RA, FP, CODE_REG, and PP (when not in precompiled mode), set up the Dart frame pointer layout, optionally load the pool pointer, and reserve local space. They also update constant pool availability and properly handle prologue offsets.

4. Helper additions:
- bool constant_pool_allowed() const
- void set_constant_pool_allowed(bool b)
- void SetPrologueOffset()

The prologue offset is recorded when the first Dart frame instruction is emitted. The use of the constant pool is enabled when entering a Dart function and disabled when exiting the function.