### PR TITLE
[mips] change RegisterAlignment and StackAlignment

### DIFF
--- a/runtime/vm/constants_mips.h
+++ b/runtime/vm/constants_mips.h
@@ -347,13 +347,13 @@ class CallingConventions {
 
   // Whether larger than wordsize arguments are aligned to even registers.
   static constexpr AlignmentStrategy kArgumentRegisterAlignment =
-      kAlignedToWordSize;
+      kAlignedToWordSizeAndValueSize;
   static constexpr AlignmentStrategy kArgumentRegisterAlignmentVarArgs =
       kArgumentRegisterAlignment;
 
   // How stack arguments are aligned.
   static constexpr AlignmentStrategy kArgumentStackAlignment =
-      kAlignedToWordSize;
+      kAlignedToWordSizeAndValueSize;
   static constexpr AlignmentStrategy kArgumentStackAlignmentVarArgs =
       kArgumentStackAlignment;
 


### PR DESCRIPTION
[mips] Fix kArgumentRegisterAlignment and kArgumentStackAlignment

These values get triggered when we align stack or registers for MIPS arch.
This should be aligned to WordSizeAndValueSize.
Important for FFI and native calling convention.