### PR TITLE
[mips] This PR adds support for monomorphic checked entry stubs for both JIT and AOT compilation modes.

### DIFF
--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -218,6 +218,66 @@ void Assembler::LeaveDartFrameAndReturn(Register ra) {
   jr(ra);
 }
 
+// A0 receiver, S5 ICData entries array
+void Assembler::MonomorphicCheckedEntryJIT() {
+  has_monomorphic_entry_ = true;
+  bool saved_use_far_branches = use_far_branches();
+  set_use_far_branches(false);
+
+  const intptr_t start = CodeSize();
+
+  Label miss;
+  Bind(&miss);
+  lw(T9, Address(THR, target::Thread::switchable_call_miss_entry_offset()));
+  jr(T9);
+
+  Comment("MonomorphicCheckedEntry");
+  ASSERT_EQUAL(CodeSize() - start, target::Instructions::kMonomorphicEntryOffsetJIT);
+
+  const intptr_t cid_offset = target::Array::element_offset(0);
+  const intptr_t count_offset = target::Array::element_offset(1);
+
+  lw(T1, FieldAddress(S5, cid_offset));
+  LoadTaggedClassIdMayBeSmi(A1, A0);
+  bne(T1, A1, &miss);
+
+  lw(T1, FieldAddress(S5, count_offset));
+  AddImmediate(T1, T1, target::ToRawSmi(1));
+  sw(T1, FieldAddress(S5, count_offset));
+
+  LoadImmediate(ARGS_DESC_REG, 0);  // GC-safe for OptimizeInvokedFunction
+
+  // Fall through to unchecked entry.
+  ASSERT_EQUAL(CodeSize() - start, target::Instructions::kPolymorphicEntryOffsetJIT);
+
+  set_use_far_branches(saved_use_far_branches);
+}
+
+// A0 receiver, S5 guarded cid as Smi
+void Assembler::MonomorphicCheckedEntryAOT() {
+  has_monomorphic_entry_ = true;
+  bool saved_use_far_branches = use_far_branches();
+  set_use_far_branches(false);
+
+  const intptr_t start = CodeSize();
+
+  Label miss;
+  Bind(&miss);
+  lw(T9, Address(THR, target::Thread::switchable_call_miss_entry_offset()));
+  jr(T9);
+
+  Comment("MonomorphicCheckedEntry");
+  ASSERT_EQUAL(CodeSize() - start, target::Instructions::kMonomorphicEntryOffsetAOT);
+  LoadClassId(TMP, A0);
+  SmiTag(TMP);
+  bne(S5, TMP, &miss);
+
+  // Fall through to unchecked entry.
+  ASSERT_EQUAL(CodeSize() - start, target::Instructions::kPolymorphicEntryOffsetAOT);
+
+  set_use_far_branches(saved_use_far_branches);
+}
+
 }  // namespace compiler
 }  // namespace dart
 

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -801,6 +801,12 @@ class Assembler : public AssemblerBase {
   bool constant_pool_allowed() const { return constant_pool_allowed_; }
   void set_constant_pool_allowed(bool b) { constant_pool_allowed_ = b; }
 
+  bool use_far_branches() const {
+    return FLAG_use_far_branches || use_far_branches_;
+  }
+  
+  void set_use_far_branches(bool b) { use_far_branches_ = b; }
+
   void SetPrologueOffset() {
     if (prologue_offset_ == -1) {
       prologue_offset_ = CodeSize();

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -804,7 +804,7 @@ class Assembler : public AssemblerBase {
   bool use_far_branches() const {
     return FLAG_use_far_branches || use_far_branches_;
   }
-  
+
   void set_use_far_branches(bool b) { use_far_branches_ = b; }
 
   void SetPrologueOffset() {
@@ -832,6 +832,9 @@ class Assembler : public AssemblerBase {
   void EnterDartFrame(intptr_t frame_size, bool load_pool_pointer = true);
   void LeaveDartFrame(RestorePP restore_pp = kRestoreCallerPP);
   void LeaveDartFrameAndReturn(Register ra = RA);
+
+  void MonomorphicCheckedEntryJIT();
+  void MonomorphicCheckedEntryAOT();
   
  private:
   bool use_far_branches_;

--- a/runtime/vm/object.h
+++ b/runtime/vm/object.h
@@ -5853,7 +5853,10 @@ class Instructions : public Object {
   static constexpr intptr_t kMonomorphicEntryOffsetAOT = 6;
   static constexpr intptr_t kPolymorphicEntryOffsetAOT = 18;
 #elif defined(TARGET_ARCH_MIPS)
-  // TODO: Handle MIPS.
+  static constexpr intptr_t kMonomorphicEntryOffsetJIT = 12;
+  static constexpr intptr_t kPolymorphicEntryOffsetJIT = 68;
+  static constexpr intptr_t kMonomorphicEntryOffsetAOT = 12;
+  static constexpr intptr_t kPolymorphicEntryOffsetAOT = 32;
 #else
 #error Missing entry offsets for current architecture
 #endif


### PR DESCRIPTION
Two new assembler stubs are introduced: MonomorphicCheckedEntryJIT and MonomorphicCheckedEntryAOT. These stubs check the class ID in register A0 and count how many times the monomorphic function is successfully invoked.