### PR TITLE
[mips] Add stub_code_compiler_mips.cc with initial MIPS FFI stubs

### DIFF
--- a/runtime/vm/compiler/assembler/assembler_base.cc
+++ b/runtime/vm/compiler/assembler/assembler_base.cc
@@ -21,8 +21,8 @@ DEFINE_FLAG(bool,
             false,
             "Verify instructions offset in code object."
             "NOTE: This breaks the profiler.");
-#if defined(TARGET_ARCH_ARM)
-DEFINE_FLAG(bool, use_far_branches, false, "Enable far branches for ARM.");
+#if defined(TARGET_ARCH_ARM) || defined(TARGET_ARCH_MIPS)
+DEFINE_FLAG(bool, use_far_branches, false, "Enable far branches for ARM and MIPS.");
 #endif
 
 namespace compiler {

--- a/runtime/vm/compiler/assembler/assembler_base.h
+++ b/runtime/vm/compiler/assembler/assembler_base.h
@@ -21,7 +21,8 @@
 namespace dart {
 
 #if defined(TARGET_ARCH_ARM) || defined(TARGET_ARCH_ARM64) ||                  \
-    defined(TARGET_ARCH_RISCV32) || defined(TARGET_ARCH_RISCV64)
+    defined(TARGET_ARCH_RISCV32) || defined(TARGET_ARCH_RISCV64) ||		         \
+    defined(TARGET_ARCH_MIPS)
 DECLARE_FLAG(bool, use_far_branches);
 #endif
 
@@ -645,7 +646,7 @@ class AssemblerBase : public StackResource {
         object_pool_builder_(object_pool_builder) {}
   virtual ~AssemblerBase();
 
-  // Used for near/far jumps on IA32/X64, ignored for ARM.
+  // Used for near/far jumps on IA32/X64, ignored for ARM and MIPS.
   enum JumpDistance : bool {
     kFarJump = false,
     kNearJump = true,

--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -36,7 +36,7 @@ void Assembler::PushRegistersInOrder(std::initializer_list<Register> regs) {
   }
 }
 
-void PushRegisterPair(Register r0, Register r1){
+void Assembler::PushRegisterPair(Register r0, Register r1){
   ASSERT(r0 != SP);
   ASSERT(r1 != SP);
 
@@ -45,7 +45,7 @@ void PushRegisterPair(Register r0, Register r1){
   sw(r0, Address(SP, 0));
 }
 
-void PopRegisterPair(Register r0, Register r1){
+void Assembler::PopRegisterPair(Register r0, Register r1){
   ASSERT(r0 != SP);
   ASSERT(r1 != SP);
 
@@ -54,12 +54,12 @@ void PopRegisterPair(Register r0, Register r1){
   addiu(SP, SP, Immediate(2 * target::kWordSize));
 }
 
-void PushImmediate(int64_t immediate){
+void Assembler::PushImmediate(int64_t immediate){
   LoadImmediate(TMP, immediate);
   Push(TMP);
 }
 
-void PushValueAtOffset(Register base, int32_t offset){
+void Assembler::PushValueAtOffset(Register base, int32_t offset){
   addiu(SP, SP, Immediate(-target::kWordSize));
   lw(TMP, Address(base, offset));
   sw(TMP, Address(SP, 0));

--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -278,6 +278,17 @@ void Assembler::MonomorphicCheckedEntryAOT() {
   set_use_far_branches(saved_use_far_branches);
 }
 
+void Assembler::ReserveAlignedFrameSpace(intptr_t frame_space) {
+  ASSERT(!in_delay_slot_);
+  // Reserve space for arguments and align frame before entering
+  // the C++ world.
+  AddImmediate(SP, -frame_space);
+  if (OS::ActivationFrameAlignment() > 1) {
+    LoadImmediate(TMP, ~(OS::ActivationFrameAlignment() - 1));
+    and_(SP, SP, TMP);
+  }
+}
+
 }  // namespace compiler
 }  // namespace dart
 

--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -265,6 +265,75 @@ void Assembler::LeaveDartFrameAndReturn(Register ra) {
   jr(ra);
 }
 
+void Assembler::EnterFullSafepoint(Register addr, Register state) {
+  // We generate the same number of instructions whether or not the slow-path is
+  // forced. This simplifies GenerateJitCallbackTrampolines.
+  Label slow_path, done, retry;
+  if (FLAG_use_slow_path) {
+    b(&slow_path);
+  }
+
+  AddImmediate(addr, THR, target::Thread::safepoint_state_offset());
+  Bind(&retry);
+  ll(state, Address(addr, 0));
+  ASSERT(TMP!=addr);
+  ASSERT(TMP!=state);
+  LoadImmediate(TMP, target::Thread::native_safepoint_state_unacquired());
+  BranchNotEqual(state, TMP, &slow_path);
+
+  LoadImmediate(state, target::Thread::native_safepoint_state_acquired());
+  sc(state, Address(addr, 0));
+  BranchEqual(state, compiler::Immediate(1),
+              &done);  // 1 means sc was successful.
+
+  if (!FLAG_use_slow_path) {
+    b(&retry);
+  }
+
+  Bind(&slow_path);
+  lw(TMP, Address(THR, target::Thread::enter_safepoint_stub_offset()));
+  lw(TMP, FieldAddress(TMP, target::Code::entry_point_offset()));
+  mov(T9, TMP);
+  jalr(T9);
+
+  Bind(&done);
+}
+
+void Assembler::ExitFullSafepoint(Register addr,
+                                  Register state,
+                                  bool ignore_unwind_in_progress) {
+  // We generate the same number of instructions whether or not the slow-path is
+  // forced, for consistency with EnterFullSafepoint.
+  Label slow_path, done, retry;
+  if (FLAG_use_slow_path) {
+    b(&slow_path);
+  }
+
+  AddImmediate(addr, THR, target::Thread::safepoint_state_offset());
+  Bind(&retry);
+  ll(state, Address(addr, 0));
+  BranchNotEqual(
+      state,
+      compiler::Immediate(target::Thread::native_safepoint_state_acquired()),
+      &slow_path);
+
+  LoadImmediate(state, target::Thread::native_safepoint_state_unacquired());
+  sc(state, Address(addr, 0));
+  BranchEqual(state, compiler::Immediate(1),
+              &done);  // 1 means sc was successful.
+
+  if (!FLAG_use_slow_path) {
+    b(&retry);
+  }
+
+  Bind(&slow_path);
+  lw(TMP, Address(THR, target::Thread::exit_safepoint_stub_offset()));
+  lw(T9, FieldAddress(TMP, target::Code::entry_point_offset()));
+  jalr(T9);
+
+  Bind(&done);
+}
+
 // A0 receiver, S5 ICData entries array
 void Assembler::MonomorphicCheckedEntryJIT() {
   has_monomorphic_entry_ = true;

--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -8,6 +8,9 @@
 #include "vm/compiler/backend/locations.h"
 
 namespace dart {
+  
+DECLARE_FLAG(bool, check_code_pointer);
+
 namespace compiler{
 
 void Assembler::EmitBranch(Opcode b, Register rs, Register rt, Label* label) {
@@ -117,6 +120,50 @@ void Assembler::LoadClassIdMayBeSmi(Register result, Register object) {
 
 void Assembler::LoadTaggedClassIdMayBeSmi(Register result, Register object) {
   UNIMPLEMENTED();
+}
+
+void Assembler::LoadPoolPointer(Register reg) {
+  ASSERT(!in_delay_slot_);
+  CheckCodePointer();
+  lw(reg, FieldAddress(CODE_REG, target::Code::object_pool_offset()));
+  set_constant_pool_allowed(reg == PP);
+}
+
+void Assembler::CheckCodePointer() {
+#ifdef DEBUG
+  if (!FLAG_check_code_pointer) {
+    return;
+  }
+  Comment("CheckCodePointer");
+  Label cid_ok, instructions_ok;
+  Push(CMPRES1);
+  Push(CMPRES2);
+  LoadClassId(CMPRES1, CODE_REG);
+  BranchEqual(CMPRES1, Immediate(kCodeCid), &cid_ok);
+  break_(0);
+  Bind(&cid_ok);
+  GetNextPC(CMPRES1, TMP);
+  const intptr_t entry_offset = CodeSize() - Instr::kInstrSize +
+                                target::Instructions::HeaderSize() - kHeapObjectTag;
+  AddImmediate(CMPRES1, CMPRES1, -entry_offset);
+  lw(CMPRES2, FieldAddress(CODE_REG, target::Code::instructions_offset()));
+  BranchEqual(CMPRES1, CMPRES2, &instructions_ok);
+  break_(1);
+  Bind(&instructions_ok);
+  Pop(CMPRES2);
+  Pop(CMPRES1);
+#endif
+}
+
+void Assembler::GetNextPC(Register dest, Register temp) {
+  if (temp != kNoRegister) {
+    mov(temp, RA);
+  }
+  EmitRegImmType(REGIMM, R0, BGEZAL, 1);
+  mov(dest, RA);
+  if (temp != kNoRegister) {
+    mov(RA, temp);
+  }
 }
 
 void Assembler::EnterFrame(intptr_t frame_size) {

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -130,6 +130,8 @@ class Assembler : public AssemblerBase {
     addiu(SP, SP, Immediate(target::kWordSize));
   }
 
+  void Ret() { jr(RA); }
+
   void CompareImmediate(Register rn, int32_t imm, OperandSize sz = kWordBytes) override;
   void TestImmediate(Register rn, int32_t imm, OperandSize sz = kWordBytes);
 

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -800,6 +800,10 @@ class Assembler : public AssemblerBase {
   void LoadClassIdMayBeSmi(Register result, Register object);
   void LoadTaggedClassIdMayBeSmi(Register result, Register object);
 
+  void LoadPoolPointer(Register reg = PP);
+  void CheckCodePointer();
+  void GetNextPC(Register dest, Register temp = kNoRegister);
+
   bool constant_pool_allowed() const { return constant_pool_allowed_; }
   void set_constant_pool_allowed(bool b) { constant_pool_allowed_ = b; }
 

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -839,6 +839,11 @@ class Assembler : public AssemblerBase {
   void LeaveDartFrame(RestorePP restore_pp = kRestoreCallerPP);
   void LeaveDartFrameAndReturn(Register ra = RA);
 
+  void EnterFullSafepoint(Register scratch0, Register scratch1);
+  void ExitFullSafepoint(Register scratch0,
+                         Register scratch1,
+                         bool ignore_unwind_in_progress);
+
   void MonomorphicCheckedEntryJIT();
   void MonomorphicCheckedEntryAOT();
 

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -837,6 +837,8 @@ class Assembler : public AssemblerBase {
 
   void MonomorphicCheckedEntryJIT();
   void MonomorphicCheckedEntryAOT();
+
+  void ReserveAlignedFrameSpace(intptr_t frame_space);
   
  private:
   bool use_far_branches_;

--- a/runtime/vm/compiler/compiler_sources.gni
+++ b/runtime/vm/compiler/compiler_sources.gni
@@ -152,6 +152,7 @@ compiler_sources = [
   "stub_code_compiler_arm.cc",
   "stub_code_compiler_arm64.cc",
   "stub_code_compiler_ia32.cc",
+  "stub_code_compiler_mips.cc",
   "stub_code_compiler_riscv.cc",
   "stub_code_compiler_x64.cc",
   "write_barrier_elimination.cc",

--- a/runtime/vm/compiler/jit/compiler.cc
+++ b/runtime/vm/compiler/jit/compiler.cc
@@ -467,10 +467,10 @@ CodePtr CompileParsedFunctionHelper::Compile() {
   EnterCompilerScope cs(thread());
 
   // We may reattempt compilation if the function needs to be assembled using
-  // far branches on ARM. In the else branch of the setjmp call, done is set to
-  // false, and use_far_branches is set to true if there is a longjmp from the
-  // ARM assembler. In all other paths through this while loop, done is set to
-  // true. use_far_branches is always false on ia32 and x64.
+  // far branches on ARM and MIPS. In the else branch of the setjmp call, done
+  // is set to false, and use_far_branches is set to true if there is a longjmp
+  // from the ARM or MIPS assembler. In all other paths through this while loop,
+  // done is set to true. use_far_branches is always false on ia32 and x64.
   volatile bool done = false;
   // volatile because the variable may be clobbered by a longjmp.
   volatile intptr_t far_branch_level = 0;

--- a/runtime/vm/compiler/stub_code_compiler_mips.cc
+++ b/runtime/vm/compiler/stub_code_compiler_mips.cc
@@ -1,0 +1,202 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+
+
+#include "vm/compiler/runtime_api.h"
+#include "vm/globals.h"
+#include "vm/compiler/backend/il.h"
+
+#define SHOULD_NOT_INCLUDE_RUNTIME
+
+#include "vm/compiler/stub_code_compiler.h"
+
+#if defined(TARGET_ARCH_MIPS)
+
+#include "vm/class_id.h"
+#include "vm/code_entry_kind.h"
+#include "vm/compiler/api/type_check_mode.h"
+#include "vm/compiler/assembler/assembler.h"
+#include "vm/compiler/backend/locations.h"
+#include "vm/constants.h"
+#include "vm/ffi_callback_metadata.h"
+#include "vm/instructions.h"
+#include "vm/static_type_exactness_state.h"
+#include "vm/tags.h"
+
+#define __ assembler->
+
+namespace dart {
+namespace compiler {
+
+void StubCodeCompiler::GenerateLoadFfiCallbackMetadataRuntimeFunction(
+    uword function_index,
+    Register dst) {
+  // Keep in sync with FfiCallbackMetadata::EnsureFirstTrampolinePageLocked.
+  // Note: If the stub was aligned, this could be a single PC relative load.
+
+  // Load a pointer to the beginning of the stub into dst.
+  const intptr_t code_size = __ CodeSize();
+
+  __ Push(RA);
+  compiler::Label label_for_getting_pc;
+  __ bal(&label_for_getting_pc);
+  __ Bind(&label_for_getting_pc);
+  //push = 2 instr, bal = 2 instr 
+  __ AddImmediate(dst, RA, -4 * compiler::target::kWordSize - code_size);
+  __ Pop(RA);
+
+  // Round dst down to the page size.
+  __ AndImmediate(dst, dst, FfiCallbackMetadata::kPageMask);
+
+  // Load the function from the function table.
+  __ LoadFromOffset(dst, dst,
+                    FfiCallbackMetadata::RuntimeFunctionOffset(function_index));
+}
+
+void StubCodeCompiler::GenerateFfiCallbackTrampolineStub() {
+#if defined(USING_SIMULATOR) && !defined(DART_PRECOMPILER)
+  // TODO(37299): FFI is not supported in SIMMIPS.
+  __ Breakpoint();
+#else
+  Label body;
+
+  // T1 is volatile and not used for passing any arguments.
+  COMPILE_ASSERT(!IsCalleeSavedRegister(T1) && !IsArgumentRegister(T1));
+  for (intptr_t i = 0; i < FfiCallbackMetadata::NumCallbackTrampolinesPerPage();
+       ++i) {
+    // The FfiCallbackMetadata table is keyed by the trampoline entry point. So
+    // look up the current PC, then jump to the shared section.
+    __ Push(RA);
+    compiler::Label label_for_getting_pc;
+    __ bal(&label_for_getting_pc);
+    __ Bind(&label_for_getting_pc);
+    //push = 2 instr, bal = 2 instr 
+    __ AddImmediate(T1, RA, -4 * compiler::target::kWordSize);
+    __ Pop(RA);
+    __ b(&body);
+  }
+
+  ASSERT_EQUAL(__ CodeSize(),
+         FfiCallbackMetadata::kNativeCallbackTrampolineSize *
+             FfiCallbackMetadata::NumCallbackTrampolinesPerPage());
+
+  __ Bind(&body);
+
+  const intptr_t shared_stub_start = __ CodeSize();
+
+  // Save THR (callee-saved), and RA.
+  COMPILE_ASSERT(FfiCallbackMetadata::kNativeCallbackTrampolineStackDelta == 2);
+  
+  __ PushRegisters(RegisterSet((1 << RA) | (1 << THR), 0));
+
+  COMPILE_ASSERT(!IsArgumentRegister(THR));
+  __ Push(T1);
+  RegisterSet argument_registers;
+  argument_registers.AddAllArgumentRegisters();
+  __ PushRegisters(argument_registers);
+
+  // Load the thread, verify the callback ID and exit the safepoint.
+  //
+  // We exit the safepoint inside DLRT_GetFfiCallbackMetadata in order to save
+  // code size on this shared stub.
+  {
+    __ EnterFrame(0);    
+    __ ReserveAlignedFrameSpace(4 * target::kWordSize);
+
+    __ mov(A0, T1);                          // trampoline
+    __ mov(A1, SPREG);                       // out_entry_point
+    __ addi(A2, SPREG, Immediate(target::kWordSize));  // out_trampoline_type
+
+    GenerateLoadFfiCallbackMetadataRuntimeFunction(
+        FfiCallbackMetadata::kGetFfiCallbackMetadata, T1);
+
+    __ mov(T9, T1);
+    __ jalr(T9);
+    __ mov(THR, V0);
+
+    __ lw(T2, Address(SPREG, 0));                  // entry_point
+    __ lw(T3, Address(SPREG, target::kWordSize));  // trampoline_type
+
+    __ LeaveFrame();
+  }
+
+  __ PopRegisters(argument_registers);
+  __ Pop(T1);
+
+  COMPILE_ASSERT(!IsCalleeSavedRegister(T2) && !IsArgumentRegister(T2));
+  COMPILE_ASSERT(!IsCalleeSavedRegister(T3) && !IsArgumentRegister(T3));
+
+  Label async_callback;
+  Label done;
+
+  // If GetFfiCallbackMetadata returned a null thread, it means that the async
+  // callback was invoked after it was deleted. In this case, do nothing.
+  __ beq(THR, ZR, &done);
+
+  // Check the trampoline type to see how the callback should be invoked.
+  COMPILE_ASSERT(
+      static_cast<uword>(FfiCallbackMetadata::TrampolineType::kSync) == 0);
+  __ bne(T3, ZR, &async_callback);
+
+  // Sync callback. The entry point contains the target function, so just call
+  // it. DLRT_GetThreadForNativeCallbackTrampoline exited the safepoint, so
+  // re-enter it afterwards.
+
+  // On entry to the function, there will be four extra slots on the stack:
+  // saved THR, R4, R5 and the return address. The target will know to skip
+  // them.
+  __ mov(T9, T2);
+  __ jalr(T9);
+
+  // Clobbers TMP, T1 and T4 -- all volatile and not holding return values.
+  __ EnterFullSafepoint(T1, T4);
+
+  __ b(&done);
+  __ Bind(&async_callback);
+
+  // Async callback. The entrypoint marshals the arguments into a message and
+  // sends it over the send port. DLRT_GetThreadForNativeCallbackTrampoline
+  // entered a temporary isolate, so exit it afterwards.
+
+  // Clobbers all volatile registers, including the callback ID in T1.
+  __ mov(T9, T2);
+  __ jalr(T9);
+
+  // Exit the temporary isolate.
+  {
+    __ EnterFrame(0);
+    __ ReserveAlignedFrameSpace(4 * target::kWordSize);
+
+    GenerateLoadFfiCallbackMetadataRuntimeFunction(
+        FfiCallbackMetadata::kExitTemporaryIsolate, T1);
+        
+    __ mov(T9, T1);
+    __ jalr(T9);
+
+    __ LeaveFrame();
+  }
+
+  __ Bind(&done);
+
+  // Returns.
+  __ PopRegisters(RegisterSet((1 << RA) | (1 << THR), 0));
+  __ Ret();
+
+  ASSERT_EQUAL(__ CodeSize() - shared_stub_start,
+                       FfiCallbackMetadata::kNativeCallbackSharedStubSize);
+  ASSERT_LESS_OR_EQUAL(__ CodeSize(), FfiCallbackMetadata::kPageSize);
+
+#if defined(DEBUG)
+  while (__ CodeSize() < FfiCallbackMetadata::kPageSize) {
+    __ Breakpoint();
+  }
+#endif
+#endif
+}
+
+}  // namespace compiler
+}  // namespace dart
+
+#endif  // defined TARGET_ARCH_MIPS

--- a/runtime/vm/constants_mips.h
+++ b/runtime/vm/constants_mips.h
@@ -243,6 +243,14 @@ const Register CALLEE_SAVED_TEMP = S5;
 // since TMP is clobbered by a far branch.
 const Register CMPRES1 = T8;
 const Register CMPRES2 = T9;
+struct InstantiationABI {
+  static constexpr Register kUninstantiatedTypeArgumentsReg = T1;
+  static constexpr Register kInstantiatorTypeArgumentsReg = T2;
+  static constexpr Register kFunctionTypeArgumentsReg = T3;
+  static constexpr Register kResultTypeArgumentsReg = V0;
+  static constexpr Register kResultTypeReg = V0;
+  static constexpr Register kScratchReg = T4;
+};
 
 typedef uint32_t RegList;
 const RegList kAllCpuRegistersList = 0xFFFFFFFF;

--- a/runtime/vm/ffi_callback_metadata.h
+++ b/runtime/vm/ffi_callback_metadata.h
@@ -343,7 +343,9 @@ class FfiCallbackMetadata {
   static constexpr intptr_t kNativeCallbackSharedStubSize = 302;
   static constexpr intptr_t kNativeCallbackTrampolineStackDelta = 2;
 #elif defined(TARGET_ARCH_MIPS)
-  // TODO: Handle MIPS.
+  static constexpr intptr_t kNativeCallbackTrampolineSize = 36;
+  static constexpr intptr_t kNativeCallbackSharedStubSize = 476;
+  static constexpr intptr_t kNativeCallbackTrampolineStackDelta = 2;
 #else
 #error What architecture?
 #endif


### PR DESCRIPTION
This PR introduces a new file stub_code_compiler_mips.cc which contains the first MIPS-specific stub functions for FFI callbacks. It includes:
- Generating PC-relative metadata access for callbacks.
- Handling sync and async FFI callbacks.
- Safepoint entry/exit and trampoline setup.
- Definitions of trampoline and shared stub sizes in FfiCallbackMetadata for MIPS.

Additionally, minor updates were made for MIPS in the assembler and compiler infrastructure:
- Enabled use_far_branches flag for MIPS.
- Implemented MIPS-specific assembler helpers (LoadPoolPointer, CheckCodePointer, EnterFullSafepoint, ExitFullSafepoint, etc.).
- Added MIPS InstantiationABI.