### PR TITLE
[mips] Add InvokeDartCode stub, entry frame verification, and ABI register definitions

### DIFF
--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -4,6 +4,8 @@
 
 #if defined(TARGET_ARCH_MIPS)
 
+#define SHOULD_NOT_INCLUDE_RUNTIME
+
 #include "vm/compiler/assembler/assembler.h"
 #include "vm/compiler/backend/locations.h"
 

--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -667,8 +667,7 @@ void Assembler::EnterFullSafepoint(Register addr, Register state) {
 }
 
 void Assembler::ExitFullSafepoint(Register addr,
-                                  Register state,
-                                  bool ignore_unwind_in_progress) {
+                                  Register state) {
   // We generate the same number of instructions whether or not the slow-path is
   // forced, for consistency with EnterFullSafepoint.
   Label slow_path, done, retry;
@@ -759,6 +758,90 @@ void Assembler::MonomorphicCheckedEntryAOT() {
   ASSERT_EQUAL(CodeSize() - start, target::Instructions::kPolymorphicEntryOffsetAOT);
 
   set_use_far_branches(saved_use_far_branches);
+}
+
+void Assembler::TransitionGeneratedToNative(Register destination_address,
+                                            Register exit_frame_fp,
+                                            Register exit_through_ffi,
+                                            Register tmp1,
+                                            bool enter_safepoint) {
+  // Save exit frame information to enable stack walking.
+  sw(exit_frame_fp,
+     Address(THR, target::Thread::top_exit_frame_info_offset()));
+
+  sw(exit_through_ffi,
+     Address(THR, target::Thread::exit_through_ffi_offset()));
+  Register tmp2 = exit_through_ffi;
+
+  VerifyInGenerated(tmp1);
+  // Mark that the thread is executing native code.
+  sw(destination_address, Address(THR, target::Thread::vm_tag_offset()));
+  LoadImmediate(tmp1, target::Thread::native_execution_state());
+  sw(tmp1, Address(THR, target::Thread::execution_state_offset()));
+
+  if (enter_safepoint) {
+    EnterFullSafepoint(tmp1, tmp2);
+  }
+}
+
+void Assembler::TransitionNativeToGenerated(Register addr,
+                                            Register state,
+                                            bool exit_safepoint,
+                                            bool set_tag) {
+  if (exit_safepoint) {
+    ExitFullSafepoint(addr, state);
+  } else {
+#if defined(DEBUG)
+    // Ensure we've already left the safepoint.
+    ASSERT(target::Thread::native_safepoint_state_acquired() != 0);
+    LoadImmediate(state, target::Thread::native_safepoint_state_acquired());
+    lw(TMP, Address(THR, target::Thread::safepoint_state_offset()));
+    and_(TMP, TMP, state);
+    Label ok;
+    BranchEqual(TMP, ZR, &ok);
+    Breakpoint();
+    Bind(&ok);
+#endif
+  }
+
+  VerifyNotInGenerated(state);
+  // Mark that the thread is executing Dart code.
+  if (set_tag) {
+    LoadImmediate(state, target::Thread::vm_tag_dart_id());
+    sw(state, Address(THR, target::Thread::vm_tag_offset()));
+  }
+  LoadImmediate(state, target::Thread::generated_execution_state());
+  sw(state, Address(THR, target::Thread::execution_state_offset()));
+
+  // Reset exit frame information in Isolate's mutator thread structure.
+  sw(ZR, Address(THR, target::Thread::top_exit_frame_info_offset()));
+  sw(ZR, Address(THR, target::Thread::exit_through_ffi_offset()));
+}
+
+void Assembler::VerifyInGenerated(Register scratch) {
+#if defined(DEBUG)
+  // Verify the thread is in generated.
+  Comment("VerifyInGenerated");
+  lw(scratch, Address(THR, target::Thread::execution_state_offset()));
+  Label ok;
+  CompareImmediate(scratch, target::Thread::generated_execution_state());
+  BranchIf(EQUAL, &ok);
+  Breakpoint();
+  Bind(&ok);
+#endif
+}
+
+void Assembler::VerifyNotInGenerated(Register scratch) {
+#if defined(DEBUG)
+  // Verify the thread is in native or VM.
+  Comment("VerifyNotInGenerated");
+  lw(scratch, Address(THR, target::Thread::execution_state_offset()));
+  CompareImmediate(scratch, target::Thread::generated_execution_state());
+  Label ok;
+  BranchIf(NOT_EQUAL, &ok, Assembler::kNearJump);
+  Breakpoint();
+  Bind(&ok);
+#endif
 }
 
 void Assembler::ReserveAlignedFrameSpace(intptr_t frame_space) {

--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -770,6 +770,21 @@ void Assembler::ReserveAlignedFrameSpace(intptr_t frame_space) {
   }
 }
 
+void Assembler::EmitEntryFrameVerification(Register scratch) {
+#if defined(DEBUG)
+  Label done;
+  ASSERT(!constant_pool_allowed());
+  LoadImmediate(scratch, target::frame_layout.exit_link_slot_from_entry_fp *
+                             target::kWordSize);
+  addu(scratch, scratch, FPREG);
+  BranchEqual(scratch, SPREG, &done);
+
+  Breakpoint();
+
+  Bind(&done);
+#endif
+}
+
 void Assembler::PushObject(const Object& object) {
   ASSERT(IsOriginalObject(object));
   ASSERT(!in_delay_slot_);

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -931,6 +931,11 @@ class Assembler : public AssemblerBase {
   void CheckCodePointer();
   void GetNextPC(Register dest, Register temp = kNoRegister);
 
+  // On some other platforms, we draw a distinction between safe and unsafe
+  // smis.
+  static bool IsSafe(const Object& object) { return true; }
+  static bool IsSafeSmi(const Object& object) { return target::IsSmi(object); }
+
   bool constant_pool_allowed() const { return constant_pool_allowed_; }
   void set_constant_pool_allowed(bool b) { constant_pool_allowed_ = b; }
 

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -5,6 +5,16 @@
 #ifndef RUNTIME_VM_ASSEMBLER_MIPS_H_
 #define RUNTIME_VM_ASSEMBLER_MIPS_H_
 
+#if defined(DART_PRECOMPILED_RUNTIME)
+#error "AOT runtime should not use compiler sources (including header files)"
+#endif  // defined(DART_PRECOMPILED_RUNTIME)
+
+#ifndef RUNTIME_VM_COMPILER_ASSEMBLER_ASSEMBLER_H_
+#error Do not include assembler_mips.h directly; use assembler.h instead.
+#endif
+
+#include <functional>
+
 #include "platform/assert.h"
 #include "vm/compiler/assembler/assembler_base.h"
 #include "vm/constants.h"

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -973,11 +973,26 @@ class Assembler : public AssemblerBase {
 
   void EnterFullSafepoint(Register scratch0, Register scratch1);
   void ExitFullSafepoint(Register scratch0,
-                         Register scratch1,
-                         bool ignore_unwind_in_progress);
+                         Register scratch1);
 
   void MonomorphicCheckedEntryJIT();
   void MonomorphicCheckedEntryAOT();
+
+  // Emit code to transition between generated mode and native mode.
+  //
+  // These require that CSP and SP are equal and aligned and require two scratch
+  // registers (in addition to TMP).
+  void TransitionGeneratedToNative(Register destination_address,
+                                   Register exit_frame_fp,
+                                   Register exit_through_ffi,
+                                   Register scratch0,
+                                   bool enter_safepoint);
+  void TransitionNativeToGenerated(Register scratch0,
+                                   Register scratch1,
+                                   bool exit_safepoint,
+                                   bool set_tag = true);
+  void VerifyInGenerated(Register scratch);
+  void VerifyNotInGenerated(Register scratch);
 
   void ReserveAlignedFrameSpace(intptr_t frame_space);
 

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -139,6 +139,18 @@ class Assembler : public AssemblerBase {
 
   void Ret() { jr(RA); }
 
+  void SmiTag(Register reg) override { sll(reg, reg, kSmiTagSize); }
+
+  void SmiTag(Register dst, Register src) { sll(dst, src, kSmiTagSize); }
+
+  void SmiUntag(Register reg) { sra(reg, reg, kSmiTagSize); }
+
+  void SmiUntag(Register dst, Register src) { sra(dst, src, kSmiTagSize); }
+
+  static Address VMTagAddress() {
+    return Address(THR, target::Thread::vm_tag_offset());
+  }
+
   void CompareImmediate(Register rn, int32_t imm, OperandSize sz = kWordBytes) override;
   void TestImmediate(Register rn, int32_t imm, OperandSize sz = kWordBytes);
 
@@ -953,6 +965,13 @@ class Assembler : public AssemblerBase {
   void MonomorphicCheckedEntryAOT();
 
   void ReserveAlignedFrameSpace(intptr_t frame_space);
+
+  // In debug mode, this generates code to check that:
+  //   FP + kExitLinkSlotFromEntryFp == SP
+  // or triggers breakpoint otherwise.
+  //
+  // Requires a scratch register in addition to the assembler temporary.
+  void EmitEntryFrameVerification(Register scratch);
 
   void PushObject(const Object& object);
 

--- a/runtime/vm/compiler/backend/il_mips.cc
+++ b/runtime/vm/compiler/backend/il_mips.cc
@@ -1,0 +1,187 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#include "vm/globals.h"  // Needed here to get TARGET_ARCH_MIPS.
+#if defined(TARGET_ARCH_MIPS)
+
+#include "vm/compiler/backend/il.h"
+
+#include "vm/compiler/backend/flow_graph_compiler.h"
+#include "vm/compiler/backend/locations.h"
+
+#define __ compiler->assembler()->
+#define Z (compiler->zone())
+
+namespace dart {
+
+#define R(r) (1 << r)
+
+LocationSummary* FfiCallInstr::MakeLocationSummary(Zone* zone,
+                                                   bool is_optimizing) const {
+  return MakeLocationSummaryInternal(
+      zone, is_optimizing,
+      (R(CallingConventions::kSecondNonArgumentRegister) |
+       R(CallingConventions::kFfiAnyNonAbiRegister) | R(CALLEE_SAVED_TEMP)));
+}
+
+#undef R
+
+
+void FfiCallInstr::EmitNativeCode(FlowGraphCompiler* compiler) {
+  const Register target = locs()->in(TargetAddressIndex()).reg();
+
+  // The temps are indexed according to their register number.
+  const Register temp1 = locs()->temp(0).reg();
+  // For regular calls, this holds the FP for rebasing the original locations
+  // during EmitParamMoves.
+  // For leaf calls, this holds the SP used to restore the pre-aligned SP after
+  // the call.
+  const Register saved_fp_or_sp = locs()->temp(1).reg();
+  const Register temp2 = locs()->temp(2).reg();
+
+  ASSERT(temp1 != target);
+  ASSERT(temp2 != target);
+  ASSERT(temp1 != saved_fp_or_sp);
+  ASSERT(temp2 != saved_fp_or_sp);
+  ASSERT(saved_fp_or_sp != target);
+
+  // Ensure these are callee-saved register and are preserved across the call.
+  ASSERT(IsCalleeSavedRegister(saved_fp_or_sp));
+  // Other temps don't need to be preserved.
+
+  __ mov(saved_fp_or_sp, is_leaf_ ? SPREG : FPREG);
+
+  if (!is_leaf_) {
+    // Make a space to put the return address.
+    __ Push(ZR);
+
+    // We need to create a dummy "exit frame". It will have a null code object.
+    __ LoadObject(CODE_REG, Object::null_object());
+    __ set_constant_pool_allowed(false);
+    __ EnterDartFrame(0, /*load_pool_pointer=*/false);
+  }
+
+  __ ReserveAlignedFrameSpace((marshaller_.RequiredStackSpaceInBytes()==0) ? 
+                              4 * kWordSize : marshaller_.RequiredStackSpaceInBytes());
+  if (FLAG_target_memory_sanitizer) {
+    UNIMPLEMENTED();
+  }
+
+  EmitParamMoves(compiler, is_leaf_ ? FPREG : saved_fp_or_sp, temp1, temp2);
+
+  if (compiler::Assembler::EmittingComments()) {
+    __ Comment(is_leaf_ ? "Leaf Call" : "Call");
+  }
+
+  if (is_leaf_) {
+#if !defined(PRODUCT)
+    // Set the thread object's top_exit_frame_info and VMTag to enable the
+    // profiler to determine that thread is no longer executing Dart code.
+    __ StoreToOffset(FPREG, THR,
+                     compiler::target::Thread::top_exit_frame_info_offset());
+    __ StoreToOffset(target, THR, compiler::target::Thread::vm_tag_offset());
+#endif
+    __ mov(T9, target);
+    __ jalr(T9);
+
+#if !defined(PRODUCT)
+    __ LoadImmediate(temp1, compiler::target::Thread::vm_tag_dart_id());
+    __ StoreToOffset(temp1, THR, compiler::target::Thread::vm_tag_offset());
+    __ StoreToOffset(ZR, THR,
+                     compiler::target::Thread::top_exit_frame_info_offset());
+#endif
+  } else {
+    // We need to copy a dummy return address up into the dummy stack frame so
+    // the stack walker will know which safepoint to use.
+    compiler::Label label_for_getting_pc;
+    __ bal(&label_for_getting_pc);
+    __ Bind(&label_for_getting_pc);
+    __ addiu(RA, RA, compiler::Immediate(8));
+    __ StoreToOffset(RA, FPREG, kSavedCallerPcSlotFromFp * kWordSize);
+    compiler->EmitCallsiteMetadata(source(), deopt_id(),
+                                   UntaggedPcDescriptors::Kind::kOther, locs(),
+                                   env());
+
+    if (CanExecuteGeneratedCodeInSafepoint()) {
+      // Update information in the thread object and enter a safepoint.
+      __ LoadImmediate(temp1, compiler::target::Thread::exit_through_ffi());
+      __ TransitionGeneratedToNative(target, FPREG, temp1, temp2,
+                                     /*enter_safepoint=*/true);
+
+      __ mov(T9, target);
+      __ jalr(T9);
+
+      // Update information in the thread object and leave the safepoint.
+      __ TransitionNativeToGenerated(temp1, temp2, /*leave_safepoint=*/true);
+    } else {
+      // Update information in the thread object and enter a safepoint.
+      // Outline state transition. In AOT, for code size. In JIT, because we
+      // cannot trust that code will be executable.
+      __ lw(temp1,
+            compiler::Address(
+                THR, compiler::target::Thread::
+                         call_native_through_safepoint_entry_point_offset()));
+
+      // Calls T0 and clobbers S1 (along with volatile registers).
+      ASSERT(target == T0);
+      __ mov(T9, temp1);
+      __ jalr(T9);
+    }
+
+    if (marshaller_.IsHandleCType(compiler::ffi::kResultIndex)) {
+      __ Comment("Check Dart_Handle for Error.");
+      ASSERT(temp1 != CallingConventions::kReturnReg);
+      ASSERT(temp2 != CallingConventions::kReturnReg);
+      compiler::Label not_error;
+      __ LoadFromOffset(temp1, CallingConventions::kReturnReg,
+                        compiler::target::LocalHandle::ptr_offset());
+      __ BranchIfSmi(temp1, &not_error);
+      __ LoadClassId(temp1, temp1);
+      __ RangeCheck(temp1, temp2, kFirstErrorCid, kLastErrorCid,
+                    compiler::AssemblerBase::kIfNotInRange, &not_error);
+
+      // Slow path, use the stub to propagate error, to save on code-size.
+      __ Comment("Slow path: call Dart_PropagateError through stub.");
+      __ lw(temp1,
+            compiler::Address(
+                THR, compiler::target::Thread::
+                         call_native_through_safepoint_entry_point_offset()));
+      __ lw(target, compiler::Address(
+                        THR, kPropagateErrorRuntimeEntry.OffsetFromThread()));
+      __ mov(CallingConventions::ArgumentRegisters[0], CallingConventions::kReturnReg);
+      ASSERT(target == T0);
+      __ mov(T9, temp1);
+      __ jalr(T9);
+#if defined(DEBUG)
+      // We should never return with normal controlflow from this.
+      __ Breakpoint();
+#endif
+
+      __ Bind(&not_error);
+    }
+
+    // Restore the global object pool after returning from runtime.
+    if (FLAG_precompiled_mode) {
+    __ lw(PP, compiler::Address(THR, compiler::target::Thread::global_object_pool_offset()));
+    }
+  }
+
+  EmitReturnMoves(compiler, temp1, temp2);
+
+  if (is_leaf_) {
+    // Restore the pre-aligned SP.
+    __ mov(SPREG, saved_fp_or_sp);
+  } else {
+    // Leave dummy exit frame.
+    __ LeaveDartFrame();
+    __ set_constant_pool_allowed(true);
+
+    // Instead of returning to the "fake" return address, we just pop it.
+    __ PopRegister(temp1);
+  }
+}
+
+}  // namespace dart
+
+#endif  // defined TARGET_ARCH_MIPS

--- a/runtime/vm/compiler/backend/locations_helpers.h
+++ b/runtime/vm/compiler/backend/locations_helpers.h
@@ -438,6 +438,8 @@ void InvokeEmitter(
 
 #elif defined(TARGET_ARCH_RISCV64)
 
+#elif defined(TARGET_ARCH_MIPS)
+
 #else
 #error Unknown architecture.
 #endif

--- a/runtime/vm/compiler/compiler_sources.gni
+++ b/runtime/vm/compiler/compiler_sources.gni
@@ -66,6 +66,7 @@ compiler_sources = [
   "backend/il_arm.cc",
   "backend/il_arm64.cc",
   "backend/il_ia32.cc",
+  "backend/il_mips.cc",
   "backend/il_printer.cc",
   "backend/il_printer.h",
   "backend/il_riscv.cc",

--- a/runtime/vm/compiler/ffi/abi.cc
+++ b/runtime/vm/compiler/ffi/abi.cc
@@ -38,7 +38,7 @@ static_assert(offsetof(AbiAlignmentDouble, d) == 4,
 static_assert(offsetof(AbiAlignmentUint64, i) == 4,
               "FFI transformation alignment");
 #elif defined(HOST_ARCH_IA32) && defined(DART_HOST_OS_WINDOWS) ||              \
-    defined(HOST_ARCH_ARM)
+    defined(HOST_ARCH_ARM) || defined(HOST_ARCH_MIPS)
 static_assert(offsetof(AbiAlignmentDouble, d) == 8,
               "FFI transformation alignment");
 static_assert(offsetof(AbiAlignmentUint64, i) == 8,
@@ -73,6 +73,8 @@ static_assert(offsetof(AbiAlignmentUint64, i) == 8,
 #define TARGET_ARCH_NAME Arm
 #elif defined(TARGET_ARCH_ARM64)
 #define TARGET_ARCH_NAME Arm64
+#elif defined(TARGET_ARCH_MIPS)
+#define TARGET_ARCH_NAME MIPS
 #elif defined(TARGET_ARCH_RISCV32)
 #define TARGET_ARCH_NAME Riscv32
 #elif defined(TARGET_ARCH_RISCV64)

--- a/runtime/vm/compiler/ffi/abi.h
+++ b/runtime/vm/compiler/ffi/abi.h
@@ -34,6 +34,7 @@ enum class Abi {
   kLinuxArm,
   kLinuxArm64,
   kLinuxIA32,
+  kLinuxMIPS,
   kLinuxX64,
   kLinuxRiscv32,
   kLinuxRiscv64,
@@ -51,9 +52,9 @@ const int64_t num_abis = static_cast<int64_t>(Abi::kWindowsX64) + 1;
 // - runtime/vm/compiler/frontend/kernel_to_il.cc
 static_assert(static_cast<int64_t>(Abi::kAndroidArm) == 0,
               "Enum value unexpected.");
-static_assert(static_cast<int64_t>(Abi::kWindowsX64) == 21,
+static_assert(static_cast<int64_t>(Abi::kWindowsX64) == 22,
               "Enum value unexpected.");
-static_assert(num_abis == 22, "Enum value unexpected.");
+static_assert(num_abis == 23, "Enum value unexpected.");
 
 // The target ABI. Defines sizes and alignment of native types.
 Abi TargetAbi();

--- a/runtime/vm/compiler/ffi/native_calling_convention.cc
+++ b/runtime/vm/compiler/ffi/native_calling_convention.cc
@@ -117,6 +117,11 @@ class ArgumentAllocator : public ValueObject {
       BlockAllFpuRegisters();
     }
 #endif
+#if defined(TARGET_ARCH_MIPS)
+    if(has_varargs_){
+      BlockAllFpuRegisters();
+    }
+#endif
     const auto& result = AllocateArgument(payload_type, is_vararg);
 #if defined(TARGET_ARCH_X64) && defined(DART_TARGET_OS_WINDOWS)
     if (has_varargs_) {
@@ -177,6 +182,21 @@ class ArgumentAllocator : public ValueObject {
       if (CallingConventions::kArgumentIntRegXorFpuReg) {
         cpu_regs_used++;
       }
+#if defined(TARGET_ARCH_MIPS)
+      // MIPS O32 hard float ABI: when a scalar float uses an FPU register,
+      // the corresponding integer register slot(s) are consumed.
+      // $f12 at position 0 → consumes $4
+      // $f14 at position 2 → consumes $6
+      if (fpu_reg_parts_used >= 0x4) BlockAllFpuRegisters();
+      if (kind == kSingleFpuReg) {
+        // Single float: consumes 1 slot (4 bytes)
+        cpu_regs_used++;
+      } else if (kind == kDoubleFpuReg) {
+        // Double: consumes 2 slots (8 bytes), must be at even position
+        cpu_regs_used += 2;
+        if (cpu_regs_used == 3) cpu_regs_used = 4;
+      }
+#endif
 #if defined(TARGET_ARCH_ARM)
       if (kind == kSingleFpuReg) {
         return *new (zone_)
@@ -189,10 +209,31 @@ class ArgumentAllocator : public ValueObject {
                                        static_cast<DRegister>(reg_index));
       }
 #endif
+#if defined(TARGET_ARCH_MIPS)
+      // MIPS O32 ABI: FPU argument registers are $f12 and $f14.
+      // FpuArgumentRegisters contains D registers: D6 ($f12/$f13), D7 ($f14/$f15).
+      // For single floats: index 0 -> D6 ($f12), index 2 -> D7 ($f14)
+      // For doubles: index 0 -> D6, index 1 -> D7
+      // We store the DRegister value and use the kind to distinguish single vs double.
+      DRegister d_reg;
+      if (kind == kSingleFpuReg) {
+        // Single floats at index 0 use D6 ($f12), at index 2 use D7 ($f14)
+        d_reg = static_cast<DRegister>(CallingConventions::FpuArgumentRegisters[reg_index/2]);
+      } else if (kind == kDoubleFpuReg) {
+        // Doubles use FpuArgumentRegisters directly
+        d_reg = static_cast<DRegister>(CallingConventions::FpuArgumentRegisters[reg_index]);
+      } else {
+        UNREACHABLE();
+      }
+      return *new (zone_)
+          NativeFpuRegistersLocation(payload_type, payload_type, kind,
+                                      static_cast<intptr_t>(d_reg));
+#else
       ASSERT(kind == kQuadFpuReg);
       FpuRegister reg = CallingConventions::FpuArgumentRegisters[reg_index];
       return *new (zone_)
           NativeFpuRegistersLocation(payload_type, payload_type, reg);
+#endif
     }
 
 #if defined(TARGET_ARCH_RISCV64)
@@ -210,6 +251,14 @@ class ArgumentAllocator : public ValueObject {
       const auto& container_type = ConvertFloatToInt(zone_, payload_type);
       return AllocateInt(payload_type, container_type, is_vararg);
     }
+#elif defined(TARGET_ARCH_MIPS)
+    // After using up F registers (or when blocked by struct arguments),
+    // start bitcasting floats to integer registers.
+    if (((payload_type.SizeInBytes() == 4) && HasAvailableCpuRegisters(1)) ||
+        ((payload_type.SizeInBytes() == 8) && HasAvailableCpuRegisters(2))) {
+      const auto& container_type = ConvertFloatToInt(zone_, payload_type);
+      return AllocateInt(payload_type, container_type, is_vararg);
+    }
 #endif
 
     BlockAllFpuRegisters();
@@ -222,6 +271,10 @@ class ArgumentAllocator : public ValueObject {
   const NativeLocation& AllocateInt(const NativeType& payload_type,
                                     const NativeType& container_type,
                                     bool is_vararg) {
+#if defined(TARGET_ARCH_MIPS)
+    // Once we start using Integer registers or stack, no more FPU regs are needed.
+    BlockAllFpuRegisters();
+#endif
     if (target::kWordSize == 4 && payload_type.SizeInBytes() == 8) {
       if (CallingConventions::kArgumentRegisterAlignment ==
               kAlignedToWordSizeAndValueSize ||
@@ -479,6 +532,29 @@ class ArgumentAllocator : public ValueObject {
   }
 #endif  // defined(TARGET_ARCH_ARM64)
 
+#if defined(TARGET_ARCH_MIPS)
+  const NativeLocation& AllocateCompound(const NativeCompoundType& payload_type,
+                                         bool is_vararg,
+                                         bool is_result) {
+    const auto& compound_type = payload_type.AsCompound();
+    const auto& result = AllocateCompoundAsMultiple(compound_type);
+
+    // If any part of the struct used integer registers, block all FPU registers
+    // so that subsequent scalar floats use integer registers instead.
+    if (result.IsMultiple()) {
+      const auto& multiple = result.AsMultiple();
+      for (intptr_t i = 0; i < multiple.locations().length(); i++) {
+        if (multiple.locations()[i]->IsRegisters()) {
+          BlockAllFpuRegisters();
+          break;
+        }
+      }
+    }
+
+    return result;
+  }
+#endif  // defined(TARGET_ARCH_MIPS)
+
 #if defined(TARGET_ARCH_RISCV32) || defined(TARGET_ARCH_RISCV64)
   // See RISC-V ABIs Specification
   // https://github.com/riscv-non-isa/riscv-elf-psabi-doc/releases
@@ -562,6 +638,20 @@ class ArgumentAllocator : public ValueObject {
   // in-bounds.
   const NativeLocation& AllocateCompoundAsMultiple(
       const NativeCompoundType& compound_type) {
+#if defined(TARGET_ARCH_MIPS)
+    // MIPS O32 ABI: Structures are passed as if they were very wide integers
+    // with their size rounded up to an integral number of words.
+    // Block FPU registers since struct arguments use integer registers.
+    BlockAllFpuRegisters();
+
+    const intptr_t struct_alignment = compound_type.AlignmentInBytesField();
+    if (struct_alignment >= 8) {
+      // Align to even register (8-byte boundary)
+      cpu_regs_used += cpu_regs_used % 2;
+      // Also align stack if struct will go to stack
+      align_stack(8);
+    }
+#endif
     const intptr_t chunk_size = compiler::target::kWordSize;
     const intptr_t num_chunks =
         Utils::RoundUp(compound_type.SizeInBytes(), chunk_size) / chunk_size;
@@ -584,7 +674,8 @@ class ArgumentAllocator : public ValueObject {
   }
 
   static FpuRegisterKind FpuRegKind(const NativeType& payload_type) {
-#if defined(TARGET_ARCH_ARM)
+#if defined(TARGET_ARCH_ARM) || defined(TARGET_ARCH_MIPS)
+    // ARM and MIPS both distinguish between single (float) and double precision.
     return FpuRegisterKindFromSize(payload_type.SizeInBytes());
 #else
     return kQuadFpuReg;
@@ -605,8 +696,14 @@ class ArgumentAllocator : public ValueObject {
 
   const NativeLocation& AllocateStack(const NativeType& payload_type,
                                       bool is_vararg = false) {
+#if defined(TARGET_ARCH_MIPS)
+    // Once we start using stack, no more CPU regs needed.
+    cpu_regs_used = 4;
+#endif
     align_stack(payload_type.AlignmentInBytesStack(is_vararg));
+#if !defined(TARGET_ARCH_MIPS)
     const intptr_t size = payload_type.SizeInBytes();
+#endif
     // If the stack arguments are not packed, the 32 lowest bits should not
     // contain garbage.
     const auto& container_type =
@@ -614,7 +711,11 @@ class ArgumentAllocator : public ValueObject {
     const auto& result = *new (zone_) NativeStackLocation(
         payload_type, container_type, CallingConventions::kStackPointerRegister,
         stack_height_in_bytes);
+#if defined(TARGET_ARCH_MIPS)
+    stack_height_in_bytes += container_type.SizeInBytes();
+#else
     stack_height_in_bytes += size;
+#endif
     align_stack(payload_type.AlignmentInBytesStack(is_vararg));
     return result;
   }
@@ -629,7 +730,13 @@ class ArgumentAllocator : public ValueObject {
     if (kind == kSingleFpuReg) return CallingConventions::kNumSFpuArgRegs;
     if (kind == kDoubleFpuReg) return CallingConventions::kNumDFpuArgRegs;
 #endif  // defined(TARGET_ARCH_ARM)
+#if defined(TARGET_ARCH_MIPS)
+    // MIPS has 4 FPU argument registers, usable as either S or D registers.
+    if (kind == kSingleFpuReg) return CallingConventions::kNumFArgRegs;
+    if (kind == kDoubleFpuReg) return CallingConventions::kNumFArgRegs;
+#else
     if (kind == kQuadFpuReg) return CallingConventions::kNumFpuArgRegs;
+#endif  // defined(TARGET_ARCH_MIPS)
     UNREACHABLE();
   }
 
@@ -645,7 +752,14 @@ class ArgumentAllocator : public ValueObject {
       if ((fpu_reg_parts_used & mask_shifted) == 0) {
         return index;
       }
+#if defined(TARGET_ARCH_MIPS)
+      if (size == 1)
+         index = index + 2;
+      else
+         index++;
+#else
       index++;
+#endif
     }
     return kNoFpuRegister;
   }
@@ -687,7 +801,12 @@ class ArgumentAllocator : public ValueObject {
   intptr_t cpu_regs_used = 0;
   // Every bit denotes 32 bits of FPU registers.
   intptr_t fpu_reg_parts_used = 0;
+#if defined(TARGET_ARCH_MIPS)
+  // MIPS O32 ABI requires stack space for argument registers (home space).
+  intptr_t stack_height_in_bytes = CallingConventions::kNumArgRegs * compiler::target::kWordSize;
+#else
   intptr_t stack_height_in_bytes = 0;
+#endif
   const bool has_varargs_;
   Zone* zone_;
 };
@@ -927,6 +1046,15 @@ static const NativeLocation& CompoundResultLocation(
 }
 #endif  // defined(TARGET_ARCH_ARM64)
 
+#if defined(TARGET_ARCH_MIPS)
+static const NativeLocation& CompoundResultLocation(
+    Zone* zone,
+    const NativeCompoundType& payload_type,
+    bool has_varargs) {
+  return PointerToMemoryResultLocation(zone, payload_type);
+}
+#endif  // defined(TARGET_ARCH_MIPS)
+
 #if defined(TARGET_ARCH_RISCV32) || defined(TARGET_ARCH_RISCV64)
 static const NativeLocation& CompoundResultLocation(
     Zone* zone,
@@ -953,12 +1081,17 @@ static const NativeLocation& ResultLocation(Zone* zone,
       ConvertIfSoftFp(zone, payload_type, has_varargs, /*is_result*/ true);
   const auto& container_type = payload_type_converted.Extend(
       zone, CallingConventions::kReturnRegisterExtension);
-
+#if defined(TARGET_ARCH_MIPS)
+  if (container_type.IsFloat()) {
+    return *new (zone) NativeFpuRegistersLocation(
+        payload_type, container_type, FpuRegisterKindFromSize(container_type.SizeInBytes()), CallingConventions::kReturnFpuReg);
+  }
+#else
   if (container_type.IsFloat()) {
     return *new (zone) NativeFpuRegistersLocation(
         payload_type, container_type, CallingConventions::kReturnFpuReg);
   }
-
+#endif
   if (container_type.IsInt() || container_type.IsVoid()) {
     if (container_type.SizeInBytes() == 8 && target::kWordSize == 4) {
       return *new (zone) NativeRegistersLocation(

--- a/runtime/vm/compiler/ffi/native_location.cc
+++ b/runtime/vm/compiler/ffi/native_location.cc
@@ -41,8 +41,16 @@ NativeLocation& NativeLocation::FromLocation(Zone* zone,
       return *new (zone)
           NativeRegistersLocation(zone, native_rep, native_rep, loc.reg());
     case Location::Kind::kFpuRegister:
+#if defined(TARGET_ARCH_MIPS)
+      // On MIPS, we need to determine the register kind from the native type size
+      return *new (zone)
+          NativeFpuRegistersLocation(native_rep, native_rep,
+                                     FpuRegisterKindFromSize(native_rep.SizeInBytes()),
+                                     static_cast<intptr_t>(loc.fpu_reg()));
+#else
       return *new (zone)
           NativeFpuRegistersLocation(native_rep, native_rep, loc.fpu_reg());
+#endif
     case Location::Kind::kStackSlot:
       return *new (zone)
           NativeStackLocation(native_rep, native_rep, loc.base_reg(),
@@ -307,6 +315,20 @@ void NativeRegistersLocation::PrintTo(BaseTextBuffer* f) const {
 
 void NativeFpuRegistersLocation::PrintTo(BaseTextBuffer* f) const {
   switch (fpu_reg_kind()) {
+#if defined(TARGET_ARCH_MIPS)
+    case kDoubleFpuReg: {
+      DRegister reg_d = fpu_d_reg();
+      ASSERT((0 <= reg_d) && (reg_d < kNumberOfDRegisters));
+      f->Printf("%s", fpu_reg_names[reg_d]);
+      break;
+    }
+    case kSingleFpuReg: {
+      FRegister reg_f = fpu_f_reg();
+      ASSERT((0 <= reg_f) && (reg_f < kNumberOfFRegisters));
+      f->Printf("%s", fpu_f_reg_names[reg_f]);
+      break;
+    }
+#else
     case kQuadFpuReg:
       f->Printf("%s", RegisterNames::FpuRegisterName(fpu_reg()));
       break;
@@ -318,6 +340,7 @@ void NativeFpuRegistersLocation::PrintTo(BaseTextBuffer* f) const {
       f->Printf("%s", RegisterNames::FpuSRegisterName(fpu_s_reg()));
       break;
 #endif  // defined(TARGET_ARCH_ARM)
+#endif  // defined(TARGET_ARCH_MIPS)
     default:
       UNREACHABLE_THIS();
   }

--- a/runtime/vm/compiler/ffi/native_location.h
+++ b/runtime/vm/compiler/ffi/native_location.h
@@ -263,7 +263,14 @@ class NativeFpuRegistersLocation : public NativeLocation {
   }
   virtual bool IsFpuRegisters() const { return true; }
   virtual bool IsExpressibleAsLocation() const {
+#if defined(TARGET_ARCH_MIPS)
+    // On MIPS, FpuRegister = DRegister, so kSingleFpuReg and kDoubleFpuReg
+    // both store DRegister values that can be expressed as Location.
+    return fpu_reg_kind_ == kSingleFpuReg ||
+           fpu_reg_kind_ == kDoubleFpuReg;
+#else
     return fpu_reg_kind_ == kQuadFpuReg;
+#endif
   }
 #if !defined(FFI_UNIT_TESTS)
   virtual Location AsLocation() const {
@@ -273,7 +280,14 @@ class NativeFpuRegistersLocation : public NativeLocation {
 #endif
   FpuRegisterKind fpu_reg_kind() const { return fpu_reg_kind_; }
   FpuRegister fpu_reg() const {
+#if defined(TARGET_ARCH_MIPS)
+    // On MIPS, FpuRegister = DRegister, and we store DRegister values
+    // for both single and double floats.
+    ASSERT(fpu_reg_kind_ == kSingleFpuReg ||
+           fpu_reg_kind_ == kDoubleFpuReg);
+#else
     ASSERT(fpu_reg_kind_ == kQuadFpuReg);
+#endif
     return static_cast<FpuRegister>(fpu_reg_);
   }
 #if defined(TARGET_ARCH_ARM)
@@ -290,6 +304,16 @@ class NativeFpuRegistersLocation : public NativeLocation {
 
   bool IsLowestBits() const;
 #endif  // defined(TARGET_ARCH_ARM)
+#if defined(TARGET_ARCH_MIPS)
+  DRegister fpu_d_reg() const {
+    ASSERT(fpu_reg_kind_ == kDoubleFpuReg);
+    return static_cast<DRegister>(fpu_reg_);
+  }
+  FRegister fpu_f_reg() const {
+    ASSERT(fpu_reg_kind_ == kSingleFpuReg);
+    return static_cast<FRegister>(fpu_reg_*2);
+  }
+#endif  // defined(TARGET_ARCH_MIPS)
 
   virtual void PrintTo(BaseTextBuffer* f) const;
 

--- a/runtime/vm/compiler/stub_code_compiler_mips.cc
+++ b/runtime/vm/compiler/stub_code_compiler_mips.cc
@@ -196,6 +196,169 @@ void StubCodeCompiler::GenerateFfiCallbackTrampolineStub() {
 #endif
 }
 
+// Called when invoking Dart code from C++ (VM code).
+// Input parameters:
+//   RA : points to return address.
+//   A0 : target code or entry point (in AOT mode).
+//   A1 : arguments descriptor array.
+//   A2 : arguments array (address of first argument).
+//   A3 : current thread.
+void StubCodeCompiler::GenerateInvokeDartCodeStub() {
+  // Save frame pointer coming in.
+  __ Comment("InvokeDartCodeStub");
+  __ EnterFrame();
+
+  // Push code object to PC marker slot.
+  __ lw(TMP, Address(A3, target::Thread::invoke_dart_code_stub_offset()));
+  __ Push(TMP);
+
+  // Save new context and C++ ABI callee-saved registers.
+
+  // The saved vm tag, top resource, and top exit frame info.
+  const intptr_t kPreservedSlots = 4;
+  const intptr_t kPreservedRegSpace =
+     target::kWordSize *
+      (kAbiPreservedCpuRegCount + kAbiPreservedFRegCount + kPreservedSlots);
+
+  __ addiu(SP, SP, Immediate(-kPreservedRegSpace));
+  for (int i = S0; i <= S7; i++) {
+    Register r = static_cast<Register>(i);
+    const intptr_t slot = i - S0 + kPreservedSlots;
+    __ sw(r, Address(SP, slot *target::kWordSize));
+  }
+
+  for (intptr_t i = kAbiFirstPreservedFReg; i <= kAbiLastPreservedFReg;
+       i++) {
+    FRegister r = static_cast<FRegister>(i);
+    const intptr_t slot = kAbiPreservedCpuRegCount + kPreservedSlots + i -
+                          kAbiFirstPreservedFReg;
+    __ swc1(r, Address(SP, slot *target::kWordSize));
+  }
+
+  // Set up THR, which caches the current thread in Dart code.
+  if (THR != A3) {
+    __ mov(THR, A3);
+  }
+
+  // Save the current VMTag on the stack.
+  __ lw(T1, Assembler::VMTagAddress());
+  __ sw(T1, Address(SP, 3 *target::kWordSize));
+
+
+  // Save top resource and top exit frame info. Use T0 as a temporary register.
+  // StackFrameIterator reads the top exit frame info saved in this frame.
+  __ lw(T0, Address(THR, target::Thread::top_resource_offset()));
+  __ sw(ZR, Address(THR, target::Thread::top_resource_offset()));
+  __ sw(T0, Address(SP, 2 *target::kWordSize));
+  __ lw(T0, Address(THR, target::Thread::exit_through_ffi_offset()));
+  __ sw(ZR, Address(THR, target::Thread::exit_through_ffi_offset()));
+  __ sw(T0, Address(SP, 1 *target::kWordSize));
+  __ lw(T0, Address(THR, target::Thread::top_exit_frame_info_offset()));
+  __ sw(ZR, Address(THR, target::Thread::top_exit_frame_info_offset()));
+  __ sw(T0, Address(SP, 0 *target::kWordSize));
+  
+  // target::frame_layout.exit_link_slot_from_entry_fp must be kept in sync
+  // with the code below.
+  ASSERT(target::frame_layout.exit_link_slot_from_entry_fp == -25);
+
+  // In debug mode, verify that we've pushed the top exit frame info at the
+  // correct offset from FP.
+  __ EmitEntryFrameVerification(T0);
+
+  // Mark that the thread is executing Dart code.
+  __ LoadImmediate(T0, VMTag::kDartTagId);
+  __ sw(T0, Assembler::VMTagAddress());
+
+  // Load arguments descriptor array, which is passed to Dart code.
+  __ mov(ARGS_DESC_REG, A1);
+
+  // Load number of arguments into T1 and adjust count for type arguments.
+  __ LoadFieldFromOffset(T1, ARGS_DESC_REG,
+                         target::ArgumentsDescriptor::count_offset());
+  __ LoadFieldFromOffset(T3, ARGS_DESC_REG,
+                         target::ArgumentsDescriptor::type_args_len_offset());
+  __ SmiUntag(T1);
+
+  // Include the type arguments.
+  Label isZero;
+  __ beq(T3, ZR, &isZero);
+  __ LoadImmediate(T3, 1);
+  __ addu(T1, T1, T3);
+  __ Bind(&isZero);
+
+  // Compute address of 'arguments array' data area into A2.
+ __ AddImmediate(A2, A2, target::Array::data_offset() - kHeapObjectTag);
+
+  // Set up arguments for the Dart call.
+  Label push_arguments;
+  Label done_push_arguments;
+  __ beq(T1, ZR, &done_push_arguments);  // check if there are arguments.
+  __ mov(A1, ZR);
+  __ Bind(&push_arguments);
+  __ lw(A3, Address(A2));
+  __ Push(A3);
+  __ addiu(A2, A2, Immediate(target::kWordSize));
+  __ addiu(A1, A1, Immediate(1));
+  __ BranchSignedLess(A1, T1, &push_arguments);
+  __ Bind(&done_push_arguments);
+
+  if(FLAG_precompiled_mode) {
+    __ LoadImmediate(CODE_REG, 0);  // GC safe value into CODE_REG.
+    __ lw(PP, Address(THR, target::Thread::global_object_pool_offset()));
+  } else {
+    // We now load the pool pointer(PP) with a GC safe value as we are about to
+    // invoke dart code. We don't need a real object pool here.
+    __ LoadImmediate(PP, 0);  // GC safe value into PP.
+    __ mov(CODE_REG, A0);
+    __ lw(A0, FieldAddress(CODE_REG, target::Code::entry_point_offset()));
+  }
+
+  // Call the Dart code entrypoint.
+  // We are calling into Dart code, here, so there is no need to call through
+  // T9 to match the ABI.
+  __ mov(T9, A0);
+  __ jalr(T9);  // S4 is the arguments descriptor array.
+  __ Comment("InvokeDartCodeStub return");
+
+  // Get rid of arguments pushed on the stack.
+  __ AddImmediate(SP, FP, target::frame_layout.exit_link_slot_from_entry_fp * target::kWordSize);
+
+
+  // Restore the current VMTag, the saved top exit frame info and top resource
+  // back into the Thread structure.
+  __ lw(TMP, Address(SP, 0 * target::kWordSize));
+  __ sw(TMP, Address(THR, target::Thread::top_exit_frame_info_offset()));
+  __ lw(TMP, Address(SP, 1 * target::kWordSize));
+  __ sw(TMP, Address(THR, target::Thread::exit_through_ffi_offset()));
+  __ lw(TMP, Address(SP, 2 * target::kWordSize));
+  __ sw(TMP, Address(THR, target::Thread::top_resource_offset()));
+  __ lw(TMP, Address(SP, 3 * target::kWordSize));
+  __ sw(TMP, Address(THR, target::Thread::vm_tag_offset()));
+
+  // Restore C++ ABI callee-saved registers.
+  for (int i = S0; i <= S7; i++) {
+    Register r = static_cast<Register>(i);
+    const intptr_t slot = i - S0 + kPreservedSlots;
+    __ lw(r, Address(SP, slot *target::kWordSize));
+  }
+
+  for (intptr_t i = kAbiFirstPreservedFReg; i <= kAbiLastPreservedFReg;
+       i++) {
+    FRegister r = static_cast<FRegister>(i);
+    const intptr_t slot = kAbiPreservedCpuRegCount + kPreservedSlots + i -
+                          kAbiFirstPreservedFReg;
+    __ lwc1(r, Address(SP, slot *target::kWordSize));
+  }
+
+  __ addiu(SP, SP, Immediate(kPreservedRegSpace));
+
+  __ set_constant_pool_allowed(false);
+
+
+  // Restore the frame pointer and return.
+  __ LeaveFrameAndReturn();
+}
+
 }  // namespace compiler
 }  // namespace dart
 

--- a/runtime/vm/compiler/stub_code_compiler_mips.cc
+++ b/runtime/vm/compiler/stub_code_compiler_mips.cc
@@ -30,6 +30,41 @@
 namespace dart {
 namespace compiler {
 
+// Call a native function within a safepoint.
+//
+// On entry:
+//   Stack: set up for call
+//   T0: target to call
+//
+// On exit:
+//   Stack: preserved
+//   NOTFP, S2: clobbered, although normally callee-saved
+void StubCodeCompiler::GenerateCallNativeThroughSafepointStub() {
+  COMPILE_ASSERT(IsAbiPreservedRegister(S2));
+
+  __ mov(S2, RA);
+
+  __ LoadImmediate(T1, target::Thread::exit_through_ffi());
+  __ TransitionGeneratedToNative(T0, FPREG, T1 /*volatile*/, T2,
+                                 /*enter_safepoint=*/true);
+
+#if defined(DEBUG)
+  // Check SP alignment.
+  __ AndImmediate(T2 /*volatile*/, SP, ~(OS::ActivationFrameAlignment() - 1));
+  Label done;
+  __ beq(T2, SP, &done);
+  __ Breakpoint();
+  __ Bind(&done);
+#endif
+  __ mov(T9, T0);
+  __ jalr(T9);
+
+  __ TransitionNativeToGenerated(T1 /*volatile*/, T2,
+                                 /*exit_safepoint=*/true);
+
+  __ jr(S2);
+}
+
 void StubCodeCompiler::GenerateLoadFfiCallbackMetadataRuntimeFunction(
     uword function_index,
     Register dst) {

--- a/runtime/vm/constants_mips.cc
+++ b/runtime/vm/constants_mips.cc
@@ -16,11 +16,15 @@ const char* const cpu_reg_abi_names[kNumberOfCpuRegisters] = {
     "s0",  "s1",  "s2", "s3", "s4", "s5", "s6", "s7",
     "t8",  "t9",  "k0", "k1", "gp", "sp", "fp", "ra"};
 
-const char* const fpu_reg_names[kNumberOfFRegisters] = {
-    "f0", "f1", "f2",  "f3",  "f4",  "f5",  "f6",  "f7",
-    "f8", "f9", "f10", "f11", "f12", "f13", "f14", "f15",
-    "16",  "f17", "f18", "f19",  "f20",  "f21",  "f22",  "f23",
-    "f24", "f25", "f26", "f27",  "f28",  "f29",  "f30",  "f31"};
+const char* const fpu_f_reg_names[kNumberOfFRegisters] = {
+    "f0",  "f1",  "f2",  "f3",  "f4",  "f5",  "f6",  "f7",
+    "f8",  "f9",  "f10", "f11", "f12", "f13", "f14", "f15",
+    "f16", "f17", "f18", "f19", "f20", "f21", "f22", "f23",
+    "f24", "f25", "f26", "f27", "f28", "f29", "f30", "f31"};
+
+const char* const fpu_reg_names[kNumberOfDRegisters] = {
+    "d0", "d1", "d2",  "d3",  "d4",  "d5",  "d6",  "d7",
+    "d8", "d9", "d10", "d11", "d12", "d13", "d14", "d15"};
 
 }  // namespace dart
 

--- a/runtime/vm/constants_mips.h
+++ b/runtime/vm/constants_mips.h
@@ -352,12 +352,16 @@ class CallingConventions {
   static const Register ArgumentRegisters[];
   static constexpr intptr_t kArgumentRegisters = kAbiArgumentCpuRegs;
   static constexpr intptr_t kNumArgRegs = 4;
+  static constexpr Register kPointerToReturnStructRegisterCall = A0;
 
   static constexpr intptr_t kFpuArgumentRegisters = (1 << D6) | (1 << D7);
   static const FpuRegister FpuArgumentRegisters[];
   static constexpr intptr_t kNumFpuArgRegs = 2;
+  static constexpr intptr_t kNumFArgRegs = 4;
 
   static constexpr intptr_t kCalleeSaveCpuRegisters = kAbiPreservedCpuRegs;
+
+  static constexpr bool kArgumentIntRegXorFpuReg = false;
 
   static constexpr Register kReturnReg = V0;
   static constexpr Register kSecondReturnReg = V1;
@@ -397,6 +401,7 @@ struct DartCallingConvention {
 
 extern const char* const cpu_reg_names[kNumberOfCpuRegisters];
 extern const char* const cpu_reg_abi_names[kNumberOfCpuRegisters];
+extern const char* const fpu_f_reg_names[kNumberOfFRegisters];
 extern const char* const fpu_reg_names[kNumberOfFRegisters];
 
 // Registers in addition to those listed in TypeTestABI used inside the

--- a/runtime/vm/constants_mips.h
+++ b/runtime/vm/constants_mips.h
@@ -469,6 +469,11 @@ struct LateInitializationErrorABI {
   static constexpr Register kFieldReg = T2;
 };
 
+// ABI for ThrowStub.
+struct ThrowABI {
+  static constexpr Register kExceptionReg = V0;
+};
+
 // ABI for ReThrowStub.
 struct ReThrowABI {
   static constexpr Register kExceptionReg = V0;

--- a/runtime/vm/constants_mips.h
+++ b/runtime/vm/constants_mips.h
@@ -457,6 +457,13 @@ struct AssertSubtypeABI {
   // (throws if the subtype check fails).
 };
 
+// ABI for InitInstanceFieldStub.
+struct InitInstanceFieldABI {
+  static constexpr Register kInstanceReg = T1;
+  static constexpr Register kFieldReg = T2;
+  static constexpr Register kResultReg = V0;
+};
+
 // ABI for LateInitializationError stubs.
 struct LateInitializationErrorABI {
   static constexpr Register kFieldReg = T2;

--- a/runtime/vm/constants_mips.h
+++ b/runtime/vm/constants_mips.h
@@ -248,6 +248,14 @@ const Register CALLEE_SAVED_TEMP = S5;
 const Register CMPRES1 = T8;
 const Register CMPRES2 = T9;
 
+// Exception object is passed in this register to the catch handlers when an
+// exception is thrown.
+const Register kExceptionObjectReg = V0;
+
+// Stack trace object is passed in this register to the catch handlers when
+// an exception is thrown.
+const Register kStackTraceObjectReg = V1;
+
 // ABI for write barrier stub.
 const Register kWriteBarrierObjectReg = A0;
 const Register kWriteBarrierValueReg = A1;

--- a/runtime/vm/constants_mips.h
+++ b/runtime/vm/constants_mips.h
@@ -503,6 +503,12 @@ struct AllocateSmallRecordABI {
   static constexpr Register kTempReg = TMP;
 };
 
+// ABI for AllocateTypedDataArrayStub.
+struct AllocateTypedDataArrayABI {
+  static constexpr Register kResultReg = AllocateObjectABI::kResultReg;
+  static constexpr Register kLengthReg = A1;
+};
+
 // ABI for BoxDoubleStub.
 struct BoxDoubleStubABI {
   static constexpr FpuRegister kValueReg = D6;

--- a/runtime/vm/constants_mips.h
+++ b/runtime/vm/constants_mips.h
@@ -480,6 +480,12 @@ struct ReThrowABI {
   static constexpr Register kStackTraceReg = V1;
 };
 
+// ABI for RangeErrorStub.
+struct RangeErrorABI {
+  static constexpr Register kLengthReg = T1;
+  static constexpr Register kIndexReg = T2;
+};
+
 // ABI for AllocateObjectStub.
 struct AllocateObjectABI {
   static constexpr Register kResultReg = V0;

--- a/runtime/vm/constants_mips.h
+++ b/runtime/vm/constants_mips.h
@@ -243,6 +243,12 @@ const Register CALLEE_SAVED_TEMP = S5;
 // since TMP is clobbered by a far branch.
 const Register CMPRES1 = T8;
 const Register CMPRES2 = T9;
+
+// ABI for write barrier stub.
+const Register kWriteBarrierObjectReg = A0;
+const Register kWriteBarrierValueReg = A1;
+const Register kWriteBarrierSlotReg = S5;
+
 struct InstantiationABI {
   static constexpr Register kUninstantiatedTypeArgumentsReg = T1;
   static constexpr Register kInstantiatorTypeArgumentsReg = T2;

--- a/runtime/vm/constants_mips.h
+++ b/runtime/vm/constants_mips.h
@@ -5,6 +5,10 @@
 #ifndef RUNTIME_VM_CONSTANTS_MIPS_H_
 #define RUNTIME_VM_CONSTANTS_MIPS_H_
 
+#ifndef RUNTIME_VM_CONSTANTS_H_
+#error Do not include constants_mips.h directly; use constants.h instead.
+#endif
+
 #include "vm/allocation.h"
 #include "vm/constants_base.h"
 

--- a/runtime/vm/constants_mips.h
+++ b/runtime/vm/constants_mips.h
@@ -502,6 +502,12 @@ struct AllocateClosureABI {
   static constexpr Register kScratchReg = T4;
 };
 
+// ABI for Allocate{Mint,Double,Float32x4,Float64x2}Stub.
+struct AllocateBoxABI {
+  static constexpr Register kResultReg = AllocateObjectABI::kResultReg;
+  static constexpr Register kTempReg = T2;
+};
+
 // ABI for AllocateRecordStub.
 struct AllocateRecordABI {
   static constexpr Register kResultReg = AllocateObjectABI::kResultReg;

--- a/runtime/vm/constants_mips.h
+++ b/runtime/vm/constants_mips.h
@@ -354,6 +354,7 @@ class CallingConventions {
   static constexpr FpuRegister kReturnFpuReg = D0;
   static constexpr FpuRegister kSecondReturnFpuReg = D1;
 
+  static constexpr Register kFfiAnyNonAbiRegister = S2;
   static constexpr Register kFirstNonArgumentRegister = T0;
   static constexpr Register kSecondNonArgumentRegister = T1;
   static constexpr Register kStackPointerRegister = SPREG;

--- a/runtime/vm/cpu_mips.h
+++ b/runtime/vm/cpu_mips.h
@@ -5,6 +5,10 @@
 #ifndef RUNTIME_VM_CPU_MIPS_H_
 #define RUNTIME_VM_CPU_MIPS_H_
 
+#if !defined(RUNTIME_VM_CPU_H_)
+#error Do not include cpu_mips.h directly; use cpu.h instead.
+#endif
+
 #include "vm/allocation.h"
 
 namespace dart {

--- a/runtime/vm/stack_frame_mips.h
+++ b/runtime/vm/stack_frame_mips.h
@@ -42,6 +42,11 @@ static constexpr int kParamEndSlotFromFp = 1;  // One slot past last parameter.
 static constexpr int kCallerSpSlotFromFp = 2;
 static constexpr int kLastParamSlotFromEntrySp = 0;
 
+// Entry and exit frame layout.
+static constexpr int kExitLinkSlotFromEntryFp = -25;
+COMPILE_ASSERT(kAbiPreservedCpuRegCount == 8);
+COMPILE_ASSERT(kAbiPreservedFRegCount == 12);
+
 }  // namespace dart
 
 #endif  // RUNTIME_VM_STACK_FRAME_MIPS_H_

--- a/runtime/vm/stack_frame_mips.h
+++ b/runtime/vm/stack_frame_mips.h
@@ -5,6 +5,10 @@
 #ifndef RUNTIME_VM_STACK_FRAME_MIPS_H_
 #define RUNTIME_VM_STACK_FRAME_MIPS_H_
 
+#if !defined(RUNTIME_VM_STACK_FRAME_H_)
+#error Do not include stack_frame_mips.h directly; use stack_frame.h instead.
+#endif
+
 namespace dart {
 
 /* MIPS Dart Frame Layout

--- a/runtime/vm/stack_frame_mips.h
+++ b/runtime/vm/stack_frame_mips.h
@@ -46,6 +46,12 @@ static constexpr int kParamEndSlotFromFp = 1;  // One slot past last parameter.
 static constexpr int kCallerSpSlotFromFp = 2;
 static constexpr int kLastParamSlotFromEntrySp = 0;
 
+//Dart callbacks, this is the number of stack slots between
+// arguments passed on stack and arguments saved in callback prologue.
+//
+// 2 = return address (1) + saved frame pointer (1).
+constexpr intptr_t kCallbackSlotsBeforeSavedArguments = 2;
+
 // Entry and exit frame layout.
 static constexpr int kExitLinkSlotFromEntryFp = -25;
 COMPILE_ASSERT(kAbiPreservedCpuRegCount == 8);


### PR DESCRIPTION
This PR introduces several additions to the MIPS backend of the Dart VM,.

New Functions:

- Assembler::EmitEntryFrameVerification ( Generates debug-only code to check that FP + kExitLinkSlotFromEntryFp * kWordSize == SP. Triggers a breakpoint if the layout is incorrect. Helps ensure entry/exit frame integrity. )
- StubCodeCompiler::GenerateInvokeDartCodeStub ( Implements a stub for invoking Dart code from C++ (VM) code. )
- Smi helpers in Assembler (SmiTag, SmiUntag)
- Assembler::VMTagAddress


New ABI Register Definitions:

- Write barrier stub: kWriteBarrierObjectReg, kWriteBarrierValueReg, kWriteBarrierSlotReg
- FFI scratch: CallingConventions::kFfiAnyNonAbiRegister
- InitInstanceFieldABI
- ThrowABI
- RangeErrorABI
- AllocateBoxABI
- AllocateTypedDataArrayABI