### PR TITLE
[mips] Add helper functions to assembler_mips.h and ABIs to constants_mips.h

### DIFF
--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -102,6 +102,91 @@ void Assembler::TestImmediate(Register rn, int32_t imm, OperandSize sz) {
   deferred_imm_ = imm;
 }
 
+void Assembler::ArithmeticShiftRightImmediate(Register dst,
+                                              Register src,
+                                              int32_t shift,
+                                              OperandSize sz) {
+
+  ASSERT(IsSignedOperand(sz));
+  ASSERT((shift >= 0) && (shift < OperandSizeInBits(sz)));
+  if (shift == 0) {
+    return ExtendValue(dst, src, sz);
+  }
+  if (shift != 0) {
+    sra(dst, src, shift);
+  }
+}
+
+void Assembler::CompareWords(Register reg1,
+                             Register reg2,
+                             intptr_t offset,
+                             Register count,
+                             Register temp,
+                             Label* equals) {
+  ASSERT(reg1 != TMP);
+  ASSERT(reg2 != TMP);
+  ASSERT(count != TMP);
+  ASSERT(temp != TMP);
+  Label loop;
+  Bind(&loop);
+  blez(count, equals);
+  AddImmediate(count, count, -1);
+  lw(temp, FieldAddress(reg1, offset));
+  lw(TMP, FieldAddress(reg2, offset));
+  AddImmediate(reg1, reg1, target::kWordSize);
+  AddImmediate(reg2, reg2, target::kWordSize);
+  beq(temp, TMP, &loop);
+}
+
+void Assembler::AddShifted(Register dest,
+                           Register base,
+                           Register index,
+                           int32_t shift) {
+  if (shift == 0) {
+    addu(dest, index, base);
+  } else if (shift < 0) {
+    if (base != dest) {
+      sra(dest, index, -shift);
+      addu(dest, dest, base);
+    } else {
+      ASSERT(TMP != dest);
+      Push(TMP);
+      sra(TMP, index, -shift);
+      addu(dest, TMP, base);
+      Pop(TMP);
+    }
+  } else {
+    if (base != dest) {
+      sll(dest, index, shift);
+      addu(dest, dest, base);
+    } else {
+      ASSERT(TMP != dest);
+      Push(TMP);
+      sll(TMP, index, shift);
+      addu(dest, TMP, base);
+      Pop(TMP);
+    }
+  }
+}
+
+void Assembler::AddScaled(Register dest,
+                          Register base,
+                          Register index,
+                          ScaleFactor scale,
+                          int32_t disp) {
+    if (base == kNoRegister || base == ZR) {
+      if (scale == TIMES_1) {
+        AddImmediate(dest, index, disp);
+      } else {
+        sll(dest, index, scale);
+        AddImmediate(dest, disp);
+      }
+    } else {
+      AddShifted(dest, base, index, scale);
+      AddImmediate(dest, disp);
+    }
+  }
+
 // Branch to label if condition is true.
 void Assembler::BranchIf(Condition cond, Label* l, JumpDistance distance) {
   ASSERT(!in_delay_slot_);

--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -1020,6 +1020,127 @@ void Assembler::MonomorphicCheckedEntryAOT() {
   set_use_far_branches(saved_use_far_branches);
 }
 
+#ifndef PRODUCT
+void Assembler::MaybeTraceAllocation(intptr_t cid,
+                                     Label* trace,
+                                     Register temp_reg,
+                                     JumpDistance distance) {
+  ASSERT(cid > 0);
+  ASSERT(!in_delay_slot_);
+  ASSERT(temp_reg != kNoRegister);
+  LoadIsolateGroup(temp_reg);
+  lw(temp_reg, Address(temp_reg, target::IsolateGroup::class_table_offset()));
+  lw(temp_reg, Address(temp_reg, target::ClassTable::allocation_tracing_state_table_offset()));
+  LoadFromOffset(temp_reg, temp_reg, target::ClassTable::AllocationTracingStateSlotOffsetFor(cid), kUnsignedByte);
+  bne(temp_reg, ZR, trace);
+}
+
+void Assembler::MaybeTraceAllocation(Register cid,
+                                     Label* trace,
+                                     Register temp_reg,
+                                     JumpDistance distance) {
+  ASSERT(temp_reg != cid);
+  ASSERT(!in_delay_slot_);
+  ASSERT(temp_reg != kNoRegister);
+  LoadIsolateGroup(temp_reg);
+  lw(temp_reg, Address(temp_reg, target::IsolateGroup::class_table_offset()));
+  lw(temp_reg,
+    Address(temp_reg,
+            target::ClassTable::allocation_tracing_state_table_offset()));
+  AddRegisters(temp_reg, cid);
+  LoadFromOffset(temp_reg, temp_reg, target::ClassTable::AllocationTracingStateSlotOffsetFor(0), kUnsignedByte);
+  bne(temp_reg, ZR, trace);
+}
+#endif  // !PRODUCT
+
+void Assembler::TryAllocateObject(intptr_t cid,
+                                  intptr_t instance_size,
+                                  Label* failure,
+                                  JumpDistance distance,
+                                  Register instance_reg,
+                                  Register temp_reg) {
+  ASSERT(failure != nullptr);
+  ASSERT(instance_reg != kNoRegister);
+  ASSERT(instance_reg != temp_reg);
+  ASSERT(temp_reg != kNoRegister);
+  ASSERT(temp_reg != T8);
+  ASSERT(instance_size != 0);
+  ASSERT(Utils::IsAligned(instance_size,
+                          target::ObjectAlignment::kObjectAlignment));
+  if (FLAG_inline_alloc &&
+      target::Heap::IsAllocatableInNewSpace(instance_size)) {
+    lw(instance_reg, Address(THR, target::Thread::top_offset()));
+    AddImmediate(instance_reg, instance_size);
+
+    // instance_reg: potential next object start.
+    lw(T8, Address(THR, target::Thread::end_offset()));
+    // Fail if heap end unsigned less than or equal to instance_reg.
+    BranchUnsignedLessEqual(T8, instance_reg, failure);
+    CheckAllocationCanary(instance_reg, temp_reg);
+
+    // If this allocation is traced, program will jump to failure path
+    // (i.e. the allocation stub) which will allocate the object and trace the
+    // allocation call site.
+    NOT_IN_PRODUCT(MaybeTraceAllocation(cid, failure, temp_reg));
+
+    // Successfully allocated the object, now update top to point to
+    // next object start and store the class in the class field of object.
+    sw(instance_reg, Address(THR, target::Thread::top_offset()));
+
+    ASSERT(instance_size >= kHeapObjectTag);
+    AddImmediate(instance_reg, -instance_size + kHeapObjectTag);
+
+    const uword tags = target::MakeTagWordForNewSpaceObject(cid, instance_size);
+    LoadImmediate(temp_reg, tags);
+    InitializeHeader(temp_reg, instance_reg);
+  } else {
+    b(failure);
+  }
+}
+
+void Assembler::TryAllocateArray(intptr_t cid,
+                                 intptr_t instance_size,
+                                 Label* failure,
+                                 Register instance,
+                                 Register end_address,
+                                 Register temp1,
+                                 Register temp2) {
+  if (FLAG_inline_alloc &&
+      target::Heap::IsAllocatableInNewSpace(instance_size)) {
+    // If this allocation is traced, program will jump to failure path
+    // (i.e. the allocation stub) which will allocate the object and trace the
+    // allocation call site.
+    NOT_IN_PRODUCT(MaybeTraceAllocation(cid, failure, temp1));
+    // Potential new object start.
+    lw(instance, Address(THR, target::Thread::top_offset()));
+    // Potential next object start.
+    AddImmediate(end_address, instance, instance_size);
+    // Branch on unsigned overflow.
+    BranchUnsignedLess(end_address, instance, failure);
+
+    // Check if the allocation fits into the remaining space.
+    // instance: potential new object start, /* inline_isolate = */ false.
+    // end_address: potential next object start.
+    lw(temp2, Address(THR, target::Thread::end_offset()));
+    BranchUnsignedGreaterEqual(end_address, temp2, failure);
+    CheckAllocationCanary(instance, temp2);
+
+    // Successfully allocated the object(s), now update top to point to
+    // next object start and initialize the object.
+    sw(end_address, Address(THR, target::Thread::top_offset()));
+    addiu(instance, instance, Immediate(kHeapObjectTag));
+    LoadImmediate(temp1, instance_size);
+
+    // Initialize the tags.
+    // instance: new object start as a tagged pointer.
+    const uword tags = target::MakeTagWordForNewSpaceObject(cid, instance_size);
+    LoadImmediate(temp1, tags);
+    InitializeHeader(temp1, instance);  // Store tags.
+  } else {
+    b(failure);
+  }
+}
+
 void Assembler::TransitionGeneratedToNative(Register destination_address,
                                             Register exit_frame_fp,
                                             Register exit_through_ffi,

--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -292,6 +292,22 @@ void Assembler::BranchIfZero(Register rn, Label* label, JumpDistance distance) {
   beq(rn, ZR, label);
 }
 
+void Assembler::BranchIfBit(Register rn,
+                            intptr_t bit_number,
+                            Condition condition,
+                            Label* label,
+                            JumpDistance distance) {
+  ASSERT(rn != CMPRES1);
+  andi(CMPRES1, rn, compiler::Immediate(1 << bit_number));
+  if (condition == ZERO) {
+    beq(CMPRES1, ZR, label);
+  } else if (condition == NOT_ZERO) {
+    bne(CMPRES1, ZR, label);
+  } else {
+    UNREACHABLE();
+  }
+}
+
 void Assembler::SetIf(Condition condition, Register rd) {
   ASSERT(deferred_compare_ != kNone);
 
@@ -451,6 +467,21 @@ void Assembler::LoadUniqueObject(Register rd, const Object& object,
   LoadObjectHelper(rd, object, true, snapshot_behavior);
 }
 
+void Assembler::RangeCheck(Register value,
+                           Register temp,
+                           intptr_t low,
+                           intptr_t high,
+                           RangeCheckCondition condition,
+                           Label* target) {
+  Register to_check = temp != kNoRegister ? temp : value;
+  AddImmediate(to_check, value, -low);
+  if (condition == kIfInRange) {
+    BranchUnsignedLessEqual(to_check, Immediate(high - low), target);
+  } else {
+    BranchUnsignedGreater(to_check, Immediate(high - low), target);
+  }
+}
+
 void Assembler::LoadClassId(Register result, Register object) {
   UNIMPLEMENTED();
 }
@@ -466,11 +497,36 @@ void Assembler::CompareClassId(Register object,
 }
 
 void Assembler::LoadClassIdMayBeSmi(Register result, Register object) {
-  UNIMPLEMENTED();
+  ASSERT(result != object);
+  ASSERT(result != CMPRES1);
+  ASSERT(object != CMPRES1);
+  Label done;
+  LoadImmediate(result, kSmiCid);
+  BranchIfSmi(object, &done);
+  LoadClassId(result, object);
+  Bind(&done);
 }
 
 void Assembler::LoadTaggedClassIdMayBeSmi(Register result, Register object) {
-  UNIMPLEMENTED();
+  LoadClassIdMayBeSmi(result, object);
+  SmiTag(result);
+}
+
+void Assembler::EnsureHasClassIdInDEBUG(intptr_t cid,
+                                        Register src,
+                                        Register scratch,
+                                        bool can_be_null) {
+#if defined(DEBUG)
+  Comment("Check that object in register has cid %" Pd "", cid);
+  Label matches;
+  LoadClassIdMayBeSmi(scratch, src);
+  BranchEqual(scratch, compiler::Immediate(cid), &matches);
+  if (can_be_null) {
+    BranchEqual(scratch, compiler::Immediate(kNullCid), &matches);
+  }
+  Breakpoint();
+  Bind(&matches);
+#endif
 }
 
 bool Assembler::CanLoadFromObjectPool(const Object& object) const {
@@ -484,6 +540,26 @@ bool Assembler::CanLoadFromObjectPool(const Object& object) const {
 #endif
   ASSERT(IsInOldSpace(object));
   return true;
+}
+
+void Assembler::Load(Register dest, const Address& address, OperandSize sz) {
+  Address addr = PrepareLargeOffset(address.base(), address.offset());
+  switch (sz) {
+    case kByte:
+      return lb(dest, addr);
+    case kUnsignedByte:
+      return lbu(dest, addr);
+    case kTwoBytes:
+      return lh(dest, addr);
+    case kUnsignedTwoBytes:
+      return lhu(dest, addr);
+    case kUnsignedFourBytes:
+    case kFourBytes:
+      return lw(dest, addr);
+    default:
+      UNREACHABLE();
+      break;
+  }
 }
 
 void Assembler::LoadWordFromPoolIndex(Register rd,
@@ -534,6 +610,31 @@ void Assembler::StoreWordToPoolIndex(Register rs,
     } else {
       sw(rs, Address(pp, offset_low));
     }
+  }
+}
+
+void Assembler::LoadFieldAddressForRegOffset(Register address,
+                                             Register instance,
+                                             Register offset_in_words_as_smi) {
+  AddShifted(address, instance, offset_in_words_as_smi,
+             target::kWordSizeLog2 - kSmiTagShift);
+  AddImmediate(address, address, -kHeapObjectTag);
+}
+
+void Assembler::Store(Register reg, const Address& address, OperandSize sz) {
+  Address addr = PrepareLargeOffset(address.base(), address.offset());
+  switch (sz) {
+    case kUnsignedFourBytes:
+    case kFourBytes:
+      return sw(reg, addr);
+    case kUnsignedTwoBytes:
+    case kTwoBytes:
+      return sh(reg, addr);
+    case kUnsignedByte:
+    case kByte:
+      return sb(reg, addr);
+    default:
+      UNREACHABLE();
   }
 }
 
@@ -616,6 +717,14 @@ void Assembler::GetNextPC(Register dest, Register temp) {
   if (temp != kNoRegister) {
     mov(RA, temp);
   }
+}
+
+void Assembler::LoadIsolate(Register result) {
+  lw(result, Address(THR, target::Thread::isolate_offset()));
+}
+
+void Assembler::LoadIsolateGroup(Register rd) {
+  lw(rd, Address(THR, target::Thread::isolate_group_offset()));
 }
 
 void Assembler::StoreObjectIntoObjectNoBarrier(Register object,
@@ -791,6 +900,34 @@ void Assembler::VerifyStoreNeedsNoWriteBarrier(Register object,
   BranchEqual(CMPRES2, ZR, &done);
   Stop("Write barrier is required");
   Bind(&done);
+}
+
+void Assembler::ExtendValue(Register dst, Register src, OperandSize sz) {
+  switch (sz) {
+    case kUnsignedFourBytes:
+    case kFourBytes:
+      if (dst == src) return;
+      return mov(dst, src);
+    case kUnsignedTwoBytes:
+      return andi(dst, src, Immediate(0xFFFF));
+    case kTwoBytes:
+      if (dst != src) {
+        mov(dst, src);
+      }
+      sll(dst, dst, 16);
+      return sra(dst, dst, 16);
+    case kUnsignedByte:
+      return andi(dst, src, Immediate(0xFF));
+    case kByte:
+      if (dst != src) {
+        mov(dst, src);
+      }
+      sll(dst, dst, 24);
+      return sra(dst, dst, 24);
+    default:
+      UNIMPLEMENTED();
+      break;
+  }
 }
 
 void Assembler::EnterFrame(intptr_t frame_size) {
@@ -1020,6 +1157,42 @@ void Assembler::MonomorphicCheckedEntryAOT() {
   set_use_far_branches(saved_use_far_branches);
 }
 
+void Assembler::CombineHashes(Register dst, Register other) {
+  // hash += other_hash
+  addu(dst, dst, other);
+  // hash += hash << 10
+  sll(other, dst, 10);
+  addu(dst, dst, other);
+  // hash ^= hash >> 6
+  srl(other, dst, 6);
+  xor_(dst, dst, other);
+}
+
+void Assembler::FinalizeHashForSize(intptr_t bit_size,
+                                    Register hash,
+                                    Register scratch) {
+  ASSERT(bit_size > 0);
+  ASSERT(bit_size <= kBitsPerInt32);
+  ASSERT(scratch != kNoRegister);
+  // hash += hash << 3;
+  sll(scratch, hash, 3);
+  addu(hash, hash, scratch);
+  // hash ^= hash >> 11;  // Logical shift, unsigned hash.
+  srl(scratch, hash, 11);
+  xor_(hash, hash, scratch);
+  // hash += hash << 15;
+  sll(scratch, hash, 15);
+  addu(hash, hash, scratch);
+
+  // Size to fit.
+  if (bit_size < kBitsPerInt32) {
+    AndImmediate(hash, hash, Utils::NBitMask(bit_size));
+  }
+  // return (hash == 0) ? 1 : hash;
+  LoadImmediate(CMPRES1, 1);
+  movz(hash, CMPRES1, hash);  // If hash is 0, set to 1.
+}
+
 #ifndef PRODUCT
 void Assembler::MaybeTraceAllocation(intptr_t cid,
                                      Label* trace,
@@ -1139,6 +1312,22 @@ void Assembler::TryAllocateArray(intptr_t cid,
   } else {
     b(failure);
   }
+}
+
+void Assembler::CopyMemoryWords(Register src,
+                                Register dst,
+                                Register size,
+                                Register temp) {
+  Label loop, done;
+  beq(size, ZR, &done);
+  Bind(&loop);
+  lw(temp, Address(src));
+  AddImmediate(src, src, target::kWordSize);
+  sw(temp, Address(dst));
+  AddImmediate(dst, dst, target::kWordSize);
+  AddImmediate(size, size, -target::kWordSize);
+  bne(size, ZR, &loop);
+  Bind(&done);
 }
 
 void Assembler::TransitionGeneratedToNative(Register destination_address,

--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -618,6 +618,181 @@ void Assembler::GetNextPC(Register dest, Register temp) {
   }
 }
 
+void Assembler::StoreObjectIntoObjectNoBarrier(Register object,
+                                               const Address& address,
+                                               const Object& value,
+                                               MemoryOrder memory_order,
+                                               OperandSize size) {
+  ASSERT(IsOriginalObject(value));
+  ASSERT(!in_delay_slot_);
+  DEBUG_ASSERT(IsNotTemporaryScopedHandle(value));
+
+  Register value_reg;
+  if (IsSameObject(compiler::NullObject(), value)) {
+    ASSERT(object != TMP);
+    LoadObject(TMP, compiler::NullObject());
+    value_reg = TMP;
+  } else if (target::IsSmi(value) && (target::ToRawSmi(value) == 0)) {
+    value_reg = ZR;
+  } else {
+    ASSERT(object != TMP);
+    LoadObject(TMP, value);
+    value_reg = TMP;
+  }
+  if (memory_order == kRelease) {
+    sync(0);
+  }
+  Store(value_reg, address, size);
+}
+
+void Assembler::StoreBarrier(Register object,
+                             Register value,
+                             CanBeSmi can_value_be_smi,
+                             Register scratch) {
+  // x.slot = x. Barrier should have be removed at the IL level.
+  ASSERT(object != value);
+  ASSERT(object != scratch);
+  ASSERT(value != scratch);
+  ASSERT(object != RA);
+  ASSERT(value != RA);
+  ASSERT(scratch != RA);
+  ASSERT(scratch != kNoRegister);
+
+  Label done;
+  if (can_value_be_smi == kValueCanBeSmi) {
+    BranchIfSmi(value, &done, kNearJump);
+  } else {
+#if defined(DEBUG)
+    Label passed_check;
+    BranchIfNotSmi(value, &passed_check, kNearJump);
+    Breakpoint();
+    Bind(&passed_check);
+#endif
+  }
+  Push(RA);
+  lbu(scratch, FieldAddress(object, target::Object::tags_offset()));
+  lbu(RA, FieldAddress(value, target::Object::tags_offset()));
+  srl(scratch, scratch, target::UntaggedObject::kBarrierOverlapShift);
+  and_(scratch, scratch, RA);
+  lw(RA, Address(THR, target::Thread::write_barrier_mask_offset()));
+  and_(RA, RA, scratch);
+
+  Label restore_and_done;
+
+  BranchEqual(RA, ZR, &restore_and_done);
+
+  Register objectForCall = object;
+  if (value != kWriteBarrierValueReg) {
+    if (object != kWriteBarrierValueReg) {
+      Push(kWriteBarrierValueReg);
+    } else {
+      COMPILE_ASSERT(S1 != kWriteBarrierValueReg);
+      COMPILE_ASSERT(S2 != kWriteBarrierValueReg);
+      objectForCall = (value == S1) ? S2 : S1;
+      Push(kWriteBarrierValueReg);
+      Push(objectForCall);
+      mov(objectForCall, object);
+    }
+    mov(kWriteBarrierValueReg, value);
+  }
+
+  generate_invoke_write_barrier_wrapper_(objectForCall);
+
+  if (value != kWriteBarrierValueReg) {
+    if (object != kWriteBarrierValueReg) {
+      Pop(kWriteBarrierValueReg);
+    } else {
+      Pop(objectForCall);
+      Pop(kWriteBarrierValueReg);
+    }
+  }
+
+  Bind(&restore_and_done);
+  Pop(RA);
+  Bind(&done);
+}
+
+void Assembler::ArrayStoreBarrier(Register object,
+                                  Register slot,
+                                  Register value,
+                                  CanBeSmi can_value_be_smi,
+                                  Register scratch) {
+  ASSERT(object != slot);
+  ASSERT(object != value);
+  ASSERT(object != scratch);
+  ASSERT(slot != value);
+  ASSERT(slot != scratch);
+  ASSERT(value != scratch);
+  ASSERT(object != RA);
+  ASSERT(slot != RA);
+  ASSERT(value != RA);
+  ASSERT(scratch != RA);
+  ASSERT(scratch != kNoRegister);
+
+  // In parallel, test whether
+  //  - object is old and not remembered and value is new, or
+  //  - object is old and value is old and not marked and concurrent marking is
+  //    in progress
+  // If so, call the WriteBarrier stub, which will either add object to the
+  // store buffer (case 1) or add value to the marking stack (case 2).
+  // Compare UntaggedObject::StorePointer.
+  Label done;
+  if (can_value_be_smi == kValueCanBeSmi) {
+    BranchIfSmi(value, &done, kNearJump);
+  } else {
+#if defined(DEBUG)
+    Label passed_check;
+    BranchIfNotSmi(value, &passed_check, kNearJump);
+    Breakpoint();
+    Bind(&passed_check);
+#endif
+  }
+  Push(RA);
+  lbu(scratch, FieldAddress(object, target::Object::tags_offset()));
+  lbu(RA, FieldAddress(value, target::Object::tags_offset()));
+  srl(scratch, scratch, target::UntaggedObject::kBarrierOverlapShift);
+  and_(scratch, scratch, RA);
+  lw(RA, Address(THR, target::Thread::write_barrier_mask_offset()));
+  and_(RA, RA, scratch);
+
+  Label restore_and_done;
+
+  BranchEqual(RA, ZR, &restore_and_done);
+
+  if ((object != kWriteBarrierObjectReg) || (value != kWriteBarrierValueReg) ||
+      (slot != kWriteBarrierSlotReg)) {
+    // Spill and shuffle unimplemented. Currently StoreIntoArray is only used
+    // from StoreIndexInstr, which gets these exact registers from the register
+    // allocator.
+    UNIMPLEMENTED();
+  }
+  generate_invoke_array_write_barrier_();
+
+  Bind(&restore_and_done);
+  Pop(RA);
+  Bind(&done);
+}
+
+void Assembler::VerifyStoreNeedsNoWriteBarrier(Register object,
+                                               Register value) {
+  if (value == ZR) return;
+  // We can't assert the incremental barrier is not needed here, only the
+  // generational barrier. We sometimes omit the write barrier when 'value' is
+  // a constant, but we don't eagerly mark 'value' and instead assume it is also
+  // reachable via a constant pool, so it doesn't matter if it is not traced via
+  // 'object'.
+  Label done;
+  BranchIfSmi(value, &done, kNearJump);
+  lbu(CMPRES2, FieldAddress(value, target::Object::tags_offset()));
+  andi(CMPRES2, CMPRES2, Immediate(1 << target::UntaggedObject::kNewOrEvacuationCandidateBit));
+  BranchEqual(CMPRES2, ZR, &done);
+  lbu(CMPRES2, FieldAddress(object, target::Object::tags_offset()));
+  andi(CMPRES2, CMPRES2, Immediate(1 << target::UntaggedObject::kOldAndNotRememberedBit));
+  BranchEqual(CMPRES2, ZR, &done);
+  Stop("Write barrier is required");
+  Bind(&done);
+}
+
 void Assembler::EnterFrame(intptr_t frame_size) {
   ASSERT(!in_delay_slot_);
   addiu(SP, SP, Immediate(-2 * target::kWordSize));

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -736,6 +736,73 @@ class Assembler : public AssemblerBase {
     UNIMPLEMENTED();
   }
 
+  void LslImmediate(Register rd,
+                    Register rn,
+                    int32_t shift,
+                    OperandSize sz = kEightBytes) override {
+    ASSERT((shift >= 0) && (shift < OperandSizeInBits(sz)));
+    if (shift == 0) {
+      mov(rd, rn);
+    } else {
+      sll(rd, rn, shift);
+    }
+  }
+
+  void LslImmediate(Register reg,
+                    int32_t shift,
+                    OperandSize sz = kWordBytes) override{
+    LslImmediate(reg, reg, shift, sz);
+  }
+
+    void LslRegister(Register dst, Register shift) override{
+    sllv(dst, dst, shift);
+  }
+
+  void LsrImmediate(Register rd, int32_t shift) override {
+    srl(rd, rd, shift);
+  }
+
+  void ArithmeticShiftRightImmediate(Register dst,
+                                     Register src,
+                                     int32_t shift,
+                                     OperandSize sz = kWordBytes) override;
+  void ArithmeticShiftRightImmediate(Register reg,
+                                     int32_t shift,
+                                     OperandSize sz = kWordBytes) override {
+    ArithmeticShiftRightImmediate(reg, reg, shift);
+  }
+
+  void CompareWords(Register reg1,
+                    Register reg2,
+                    intptr_t offset,
+                    Register count,
+                    Register temp,
+                    Label* equals) override;
+
+  void AddShifted(Register dest, Register base, Register index, int32_t shift);
+  void AddScaled(Register dest,
+                 Register base,
+                 Register index,
+                 ScaleFactor scale,
+                 int32_t disp) override;
+
+  void SubRegisters(Register rd, Register rs) { subu(rd, rd, rs); }
+
+  void MulImmediate(Register dst,
+                    target::word imm,
+                    OperandSize sz = kWordBytes) override{
+    if (Utils::IsPowerOfTwo(imm)) {
+      const int32_t shift = Utils::ShiftForPowerOfTwo(imm);
+      ASSERT(sz == kFourBytes);
+      sll(dst, dst, shift);
+    } else {
+      LoadImmediate(TMP, imm);
+      ASSERT(sz == kFourBytes);
+      mult( dst, TMP);
+      mflo(dst);
+    }
+  }
+
   void BranchEqual(Register rd, Register rn, Label* l) { beq(rd, rn, l); }
 
   void BranchEqual(Register rd, const Immediate& imm, Label* l) {

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -1062,6 +1062,55 @@ class Assembler : public AssemblerBase {
   void MonomorphicCheckedEntryJIT();
   void MonomorphicCheckedEntryAOT();
 
+  void LoadStaticFieldAddress(Register address,
+                              Register field,
+                              Register scratch,
+                              bool is_shared);
+
+  void MaybeTraceAllocation(intptr_t cid,
+                            Label* trace,
+                            Register temp_reg,
+                            JumpDistance distance = JumpDistance::kFarJump);
+
+  void MaybeTraceAllocation(Register cid,
+                            Label* trace,
+                            Register temp_reg,
+                            JumpDistance distance = JumpDistance::kFarJump);
+
+  void TryAllocateObject(intptr_t cid,
+                         intptr_t instance_size,
+                         Label* failure,
+                         JumpDistance distance,
+                         Register instance_reg,
+                         Register temp_reg) override;
+
+  void TryAllocateArray(intptr_t cid,
+                        intptr_t instance_size,
+                        Label* failure,
+                        Register instance,
+                        Register end_address,
+                        Register temp1,
+                        Register temp2);
+
+  void CheckAllocationCanary(Register top, Register tmp = TMP) {
+#if defined(DEBUG)
+    Label okay;
+    lw(tmp, Address(top, 0));
+    AddImmediate(tmp, tmp, -kAllocationCanary);
+    beq(tmp, ZR, &okay);
+    Stop("Allocation canary");
+    Bind(&okay);
+#endif
+  }
+
+  void WriteAllocationCanary(Register top) {
+#if defined(DEBUG)
+    ASSERT(top != TMP);
+    LoadImmediate(TMP, kAllocationCanary);
+    sw(TMP, Address(top, 0));
+#endif
+  }
+
   // Emit code to transition between generated mode and native mode.
   //
   // These require that CSP and SP are equal and aligned and require two scratch

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -109,7 +109,14 @@ class Assembler : public AssemblerBase {
         delay_slot_available_(false),
         in_delay_slot_(false),
         constant_pool_allowed_(false) {
-          UNIMPLEMENTED();
+    generate_invoke_write_barrier_wrapper_ = [&](Register reg) {
+      Call(Address(THR,
+                   target::Thread::write_barrier_wrappers_thread_offset(reg)));
+    };
+    generate_invoke_array_write_barrier_ = [&]() {
+      Call(
+          Address(THR, target::Thread::array_write_barrier_entry_point_offset()));
+    };
   }
   ~Assembler() {}
 
@@ -149,6 +156,8 @@ class Assembler : public AssemblerBase {
 
   void Ret() { jr(RA); }
 
+  void SetReturnAddress(Register value) { mov(RA, value); }
+
   void SmiTag(Register reg) override { sll(reg, reg, kSmiTagSize); }
 
   void SmiTag(Register dst, Register src) { sll(dst, src, kSmiTagSize); }
@@ -156,6 +165,21 @@ class Assembler : public AssemblerBase {
   void SmiUntag(Register reg) { sra(reg, reg, kSmiTagSize); }
 
   void SmiUntag(Register dst, Register src) { sra(dst, src, kSmiTagSize); }
+
+  void LoadInt32FromBoxOrSmi(Register result, Register value) override{
+    if (result == value) {
+      ASSERT(TMP != value);
+      MoveRegister(TMP, value);
+      value = TMP;
+    }
+    ASSERT(value != result);
+    Label done;
+    SmiUntag(result, value);
+    BranchIfSmi(value, &done, compiler::Assembler::kNearJump);
+    LoadFieldFromOffset(result, value, target::Mint::value_offset(),
+                        compiler::kFourBytes);
+    Bind(&done);
+  }
 
   static Address VMTagAddress() {
     return Address(THR, target::Thread::vm_tag_offset());
@@ -336,6 +360,8 @@ class Assembler : public AssemblerBase {
   }
 
   void break_(int32_t code) { Emit(BreakEncoding(code)); }
+
+  void Breakpoint() override { break_(0); }
 
   // FPU compare, always false.
   void cfd(DRegister ds, DRegister dt) {
@@ -893,6 +919,12 @@ class Assembler : public AssemblerBase {
                     Label* label,
                     JumpDistance distance = kFarJump);
 
+  void BranchIfBit(Register rn,
+                   intptr_t bit_number,
+                   Condition condition,
+                   Label* label,
+                   JumpDistance distance = kFarJump);
+
   void SetIf(Condition condition, Register rd);
 
   // For MIPS, the near argument is ignored.
@@ -924,6 +956,26 @@ class Assembler : public AssemblerBase {
     jr(TMP);
   }
 
+  void LoadAcquire(Register dst, const Address& address, OperandSize size = kWordBytes) override{
+    Load(dst, address, size);
+    sync(0);
+  }
+
+  void StoreRelease(Register src,
+                    const Address& address,
+                    OperandSize size = kWordBytes) override{
+    sync(0);
+    Store(src, address, size);
+  }
+
+  void CompareWithMemoryValue(Register value,
+                              Address address,
+                              OperandSize size = kWordBytes) override{
+    ASSERT_EQUAL(size, kFourBytes);
+    Load(TMP, address);
+    CompareRegisters(value, TMP);
+  }
+
   void LoadMemoryValue(Register dst, Register base, int32_t offset) {
     LoadFromOffset(dst, base, offset, kWordBytes);
   }
@@ -942,6 +994,13 @@ class Assembler : public AssemblerBase {
                         ObjectPoolBuilderEntry::SnapshotBehavior snapshot_behavior =
                           ObjectPoolBuilderEntry::kSnapshotable);
 
+  void RangeCheck(Register value,
+                  Register temp,
+                  intptr_t low,
+                  intptr_t high,
+                  RangeCheckCondition condition,
+                  Label* target) override;
+
   void LoadClassId(Register result, Register object);
   void LoadClassById(Register result, Register class_id);
   void CompareClassId(Register object,
@@ -949,13 +1008,48 @@ class Assembler : public AssemblerBase {
                     Register scratch = kNoRegister);
   void LoadClassIdMayBeSmi(Register result, Register object);
   void LoadTaggedClassIdMayBeSmi(Register result, Register object);
+  void EnsureHasClassIdInDEBUG(intptr_t cid,
+                               Register src,
+                               Register scratch,
+                               bool can_be_null = false) override;
 
   bool CanLoadFromObjectPool(const Object& object) const;
+
+  void Load(Register dest, const Address& address, OperandSize sz = kWordBytes) override;
+
+  void LoadIndexedPayload(Register dst,
+                          Register base,
+                          int32_t offset,
+                          Register index,
+                          ScaleFactor scale,
+                          OperandSize sz = kWordBytes) override{
+    AddShifted(TMP, base, index, scale);
+    LoadFromOffset(dst, TMP, offset - kHeapObjectTag, sz);
+  }
+
+  void LoadFromStack(Register dst, intptr_t depth) {
+    ASSERT(depth >= 0);
+    LoadFromOffset(dst, SPREG, depth * target::kWordSize);
+  }
+  void StoreToStack(Register src, intptr_t depth) {
+    ASSERT(depth >= 0);
+    StoreToOffset(src, SPREG, depth * target::kWordSize);
+  }
+
+  void CompareToStack(Register src, intptr_t depth){
+    CompareWithMemoryValue(src, Address(SPREG, target::kWordSize * depth));
+  }
 
   void LoadWordFromPoolIndex(Register rd, intptr_t index, Register pp = PP);
   // Note: clobbers TMP.
   void StoreWordToPoolIndex(Register rs, intptr_t index, Register pp = PP);
+
+  void LoadFieldAddressForOffset(Register reg, Register base, int32_t offset) override{
+    AddImmediate(reg, base, offset - kHeapObjectTag);
+  }
   
+  void LoadFieldAddressForRegOffset(Register address, Register instance, Register offset_in_words_as_smi) override;
+
   void LoadDFromOffset(DRegister reg, Register base, int32_t offset) {
     ASSERT(!in_delay_slot_);
     FRegister lo = static_cast<FRegister>(reg * 2);
@@ -970,6 +1064,14 @@ class Assembler : public AssemblerBase {
     FRegister hi = static_cast<FRegister>(reg * 2 + 1);
     swc1(lo, PrepareLargeOffset(base, offset));
     swc1(hi, PrepareLargeOffset(base, offset + target::kWordSize));
+  }
+
+  void Store(Register src,
+             const Address& address,
+             OperandSize sz = kWordBytes) override;
+
+  void StoreZero(const Address& address, Register temp = kNoRegister) {
+    Store(ZR, address);
   }
 
   void Call(Address target) {
@@ -998,6 +1100,23 @@ class Assembler : public AssemblerBase {
   void CheckCodePointer();
   void GetNextPC(Register dest, Register temp = kNoRegister);
 
+  void LoadIsolate(Register result);
+  void LoadIsolateGroup(Register rd);
+
+  void InitializeHeader(Register tags, Register object) {
+    sw(tags, FieldAddress(object, target::Object::tags_offset()));
+#if defined(TARGET_HAS_FAST_WRITE_WRITE_FENCE)
+    sync(0);
+#endif
+  }
+
+  void InitializeHeaderUntagged(Register tags, Register object) {
+    sw(tags, Address(object, target::Object::tags_offset()));
+#if defined(TARGET_HAS_FAST_WRITE_WRITE_FENCE)
+    sync(0);
+#endif
+  }
+
   void StoreObjectIntoObjectNoBarrier(Register object,       // Object being stored into.
                                       const Address& address,  // Offset into object.
                                       const Object& value,     // Value being stored.
@@ -1022,6 +1141,8 @@ class Assembler : public AssemblerBase {
 
   bool constant_pool_allowed() const { return constant_pool_allowed_; }
   void set_constant_pool_allowed(bool b) { constant_pool_allowed_ = b; }
+
+  void ExtendValue(Register rd, Register rm, OperandSize sz) override;
 
   bool use_far_branches() const {
     return FLAG_use_far_branches || use_far_branches_;
@@ -1061,6 +1182,12 @@ class Assembler : public AssemblerBase {
 
   void MonomorphicCheckedEntryJIT();
   void MonomorphicCheckedEntryAOT();
+
+  void CombineHashes(Register dst, Register other) override;
+
+  void FinalizeHashForSize(intptr_t bit_size,
+                           Register hash,
+                           Register scratch = TMP) override;
 
   void LoadStaticFieldAddress(Register address,
                               Register field,
@@ -1110,6 +1237,14 @@ class Assembler : public AssemblerBase {
     sw(TMP, Address(top, 0));
 #endif
   }
+
+  // Copy [size] bytes from [src] address to [dst] address.
+  // [size] should be a multiple of word size.
+  // Clobbers [src], [dst], [size] and [temp] registers.
+  void CopyMemoryWords(Register src,
+                       Register dst,
+                       Register size,
+                       Register temp);
 
   // Emit code to transition between generated mode and native mode.
   //
@@ -1250,6 +1385,9 @@ class Assembler : public AssemblerBase {
   }
 
   void JumpAndLink(intptr_t target_code_pool_index, CodeEntryKind entry_kind);
+
+  std::function<void(Register reg)> generate_invoke_write_barrier_wrapper_;
+  std::function<void()> generate_invoke_array_write_barrier_;
 };
 
 }  // namespace compiler

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -998,6 +998,23 @@ class Assembler : public AssemblerBase {
   void CheckCodePointer();
   void GetNextPC(Register dest, Register temp = kNoRegister);
 
+  void StoreObjectIntoObjectNoBarrier(Register object,       // Object being stored into.
+                                      const Address& address,  // Offset into object.
+                                      const Object& value,     // Value being stored.
+                                      MemoryOrder memory_order = kRelaxedNonAtomic,
+                                      OperandSize size = kWordBytes) override;
+
+  void StoreBarrier(Register object,  // Object being stored into.
+                    Register value,   // Value being stored.
+                    CanBeSmi can_be_smi,
+                    Register scratch) override;
+  void ArrayStoreBarrier(Register object,  // Object being stored into.
+                         Register slot,    // Slot being stored into.
+                         Register value,   // Value being stored.
+                         CanBeSmi can_be_smi,
+                         Register scratch) override;
+  void VerifyStoreNeedsNoWriteBarrier(Register object, Register value)  override;
+
   // On some other platforms, we draw a distinction between safe and unsafe
   // smis.
   static bool IsSafe(const Object& object) { return true; }

--- a/runtime/vm/constants_mips.h
+++ b/runtime/vm/constants_mips.h
@@ -270,6 +270,22 @@ struct InstantiationABI {
   static constexpr Register kScratchReg = T4;
 };
 
+// Registers in addition to those listed in InstantiationABI used inside the
+// implementation of the InstantiateTypeArguments stubs.
+struct InstantiateTAVInternalRegs {
+  // The set of registers that must be pushed/popped when probing a hash-based
+  // cache due to overlap with the registers in InstantiationABI.
+  static constexpr intptr_t kSavedRegisters =
+                          (1 << InstantiationABI::kUninstantiatedTypeArgumentsReg);
+
+  // Additional registers used to probe hash-based caches.
+  static constexpr Register kEntryStartReg = T5;
+  static constexpr Register kProbeMaskReg = T6;
+  static constexpr Register kProbeDistanceReg = T7;
+  static constexpr Register kCurrentEntryIndexReg =
+                      InstantiationABI::kUninstantiatedTypeArgumentsReg;;
+};
+
 typedef uint32_t RegList;
 const RegList kAllCpuRegistersList = 0xFFFFFFFF;
 
@@ -465,6 +481,12 @@ struct InitStaticFieldABI {
   static constexpr Register kResultReg = V0;
 };
 
+// Registers used inside the implementation of InitLateStaticFieldStub.
+struct InitLateStaticFieldInternalRegs {
+  static constexpr Register kAddressReg = T3;
+  static constexpr Register kScratchReg = T4;
+};
+
 struct AssertSubtypeABI {
   static constexpr Register kSubTypeReg = T1;
   static constexpr Register kSuperTypeReg = T2;
@@ -488,8 +510,19 @@ struct InitInstanceFieldABI {
   static constexpr Register kResultReg = V0;
 };
 
+// Registers used inside the implementation of InitLateInstanceFieldStub.
+struct InitLateInstanceFieldInternalRegs {
+  static constexpr Register kAddressReg = T3;
+  static constexpr Register kScratchReg = T4;
+};
+
 // ABI for LateInitializationError stubs.
 struct LateInitializationErrorABI {
+  static constexpr Register kFieldReg = T2;
+};
+
+// ABI for FieldAccessError stubs.
+struct FieldAccessErrorABI {
   static constexpr Register kFieldReg = T2;
 };
 
@@ -592,6 +625,33 @@ struct SuspendStubABI {
 // InitSyncStarStub).
 struct InitSuspendableFunctionStubABI {
   static constexpr Register kTypeArgsReg = A0;
+};
+
+// ABI for ResumeStub
+struct ResumeStubABI {
+  static constexpr Register kSuspendStateReg = T1;
+  static constexpr Register kTempReg = T0;
+  // Registers for the frame copying (the 1st part).
+  static constexpr Register kFrameSizeReg = T2;
+  static constexpr Register kSrcFrameReg = T3;
+  static constexpr Register kDstFrameReg = T4;
+  // Registers for control transfer.
+  // (the 2nd part, can reuse registers from the 1st part)
+  static constexpr Register kResumePcReg = T2;
+  // Can also reuse kSuspendStateReg but should not conflict with CODE_REG/PP.
+  static constexpr Register kExceptionReg = T3;
+  static constexpr Register kStackTraceReg = T4;
+};
+
+// ABI for ReturnStub (ReturnAsyncStub, ReturnAsyncNotFutureStub,
+// ReturnAsyncStarStub).
+struct ReturnStubABI {
+  static constexpr Register kSuspendStateReg = T1;
+};
+
+// ABI for AsyncExceptionHandlerStub.
+struct AsyncExceptionHandlerStubABI {
+  static constexpr Register kSuspendStateReg = T1;
 };
 
 // ABI for CloneSuspendStateStub.


### PR DESCRIPTION
This change adds the following helper functions to assembler_mips.h:
- LoadStaticFieldAddress
- MaybeTraceAllocation
- MaybeTraceAllocation
- TryAllocateObject
- TryAllocateArray
- CheckAllocationCanary
- WriteAllocationCanary
- StoreObjectIntoObjectNoBarrier
- StoreBarrier
- ArrayStoreBarrier
- VerifyStoreNeedsNoWriteBarrier
- LslImmediate
- LslRegister
- LsrImmediate
- ArithmeticShiftRightImmediate
- CompareWords
- AddShifted
- AddScaled
- SubRegisters
- MulImmediate

 The following ABIs have been added:
- InstantiateTAVInternalRegs
- InitLateStaticFieldInternalRegs
- InitLateInstanceFieldInternalRegs
- FieldAccessErrorABI
- ResumeStubABI
- ReturnStubABI
- AsyncExceptionHandlerStubABI