### PR TITLE
[mips] Add debugger support

### DIFF
--- a/runtime/vm/code_patcher_mips.cc
+++ b/runtime/vm/code_patcher_mips.cc
@@ -1,0 +1,155 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#include "vm/globals.h"  // Needed here to get TARGET_ARCH_MIPS.
+#if defined(TARGET_ARCH_MIPS)
+
+#include "vm/code_patcher.h"
+
+#include "vm/instructions.h"
+#include "vm/object.h"
+
+namespace dart {
+
+CodePtr CodePatcher::GetStaticCallTargetAt(uword return_address,
+                                            const Code& code) {
+  ASSERT(code.ContainsInstructionAt(return_address));
+  CallPattern call(return_address, code);
+  return call.TargetCode();
+}
+
+void CodePatcher::PatchStaticCallAt(uword return_address,
+                                    const Code& code,
+                                    const Code& new_target) {
+  ASSERT(code.ContainsInstructionAt(return_address));
+  CallPattern call(return_address, code);
+  call.SetTargetCode(new_target);
+}
+
+void CodePatcher::InsertDeoptimizationCallAt(uword start) {
+  UNREACHABLE();
+}
+
+CodePtr CodePatcher::GetInstanceCallAt(uword return_address,
+                                       const Code& code,
+                                       Object* ic_data) {
+  ASSERT(code.ContainsInstructionAt(return_address));
+  ICCallPattern call(return_address, code);
+  if (ic_data != nullptr) {
+    *ic_data = call.Data();
+  }
+  return call.TargetCode();
+}
+
+void CodePatcher::PatchInstanceCallAt(uword return_address,
+                                      const Code& caller_code,
+                                      const Object& data,
+                                      const Code& target) {
+  auto thread = Thread::Current();
+  thread->isolate_group()->RunWithStoppedMutators([&]() {
+    PatchInstanceCallAtWithMutatorsStopped(thread, return_address, caller_code,
+                                           data, target);
+  });
+}
+
+void CodePatcher::PatchInstanceCallAtWithMutatorsStopped(
+    Thread* thread,
+    uword return_address,
+    const Code& caller_code,
+    const Object& data,
+    const Code& target) {
+  ASSERT(caller_code.ContainsInstructionAt(return_address));
+  ICCallPattern call(return_address, caller_code);
+  call.SetData(data);
+  call.SetTargetCode(target);
+}
+
+FunctionPtr CodePatcher::GetUnoptimizedStaticCallAt(uword return_address,
+                                                    const Code& code,
+                                                    ICData* ic_data_result) {
+  ASSERT(code.ContainsInstructionAt(return_address));
+  ICCallPattern static_call(return_address, code);
+  ICData& ic_data = ICData::Handle();
+  ic_data ^= static_call.Data();
+  if (ic_data_result != nullptr) {
+    *ic_data_result = ic_data.ptr();
+  }
+  return ic_data.GetTargetAt(0);
+}
+
+void CodePatcher::PatchSwitchableCallAt(uword return_address,
+                                        const Code& caller_code,
+                                        const Object& data,
+                                        const Code& target) {
+  auto thread = Thread::Current();
+  // Ensure all threads are suspended as we update data and target pair.
+  thread->isolate_group()->RunWithStoppedMutators([&]() {
+    PatchSwitchableCallAtWithMutatorsStopped(thread, return_address,
+                                             caller_code, data, target);
+  });
+}
+
+void CodePatcher::PatchSwitchableCallAtWithMutatorsStopped(
+    Thread* thread,
+    uword return_address,
+    const Code& caller_code,
+    const Object& data,
+    const Code& target) {
+  if (FLAG_precompiled_mode) {
+    BareSwitchableCallPattern call(return_address);
+    call.SetData(data);
+    call.SetTarget(target);
+  } else {
+    SwitchableCallPattern call(return_address, caller_code);
+    call.SetData(data);
+    call.SetTarget(target);
+  }
+}
+
+uword CodePatcher::GetSwitchableCallTargetEntryAt(uword return_address,
+                                                const Code& caller_code) {
+  if (FLAG_precompiled_mode) {
+    BareSwitchableCallPattern call(return_address);
+    return call.target_entry();
+  } else {
+    SwitchableCallPattern call(return_address, caller_code);
+    return call.target_entry();
+  }
+}
+
+ObjectPtr CodePatcher::GetSwitchableCallDataAt(uword return_address,
+                                                const Code& caller_code) {
+  if (FLAG_precompiled_mode) {
+    BareSwitchableCallPattern call(return_address);
+    return call.data();
+  } else {
+    SwitchableCallPattern call(return_address, caller_code);
+    return call.data();
+  }
+}
+
+void CodePatcher::PatchNativeCallAt(uword return_address,
+                                    const Code& code,
+                                    NativeFunction target,
+                                    const Code& trampoline) {
+  Thread::Current()->isolate_group()->RunWithStoppedMutators([&]() {
+    ASSERT(code.ContainsInstructionAt(return_address));
+    NativeCallPattern call(return_address, code);
+    call.set_target(trampoline);
+    call.set_native_function(target);
+  });
+}
+
+CodePtr CodePatcher::GetNativeCallAt(uword return_address,
+                                      const Code& code,
+                                      NativeFunction* target) {
+  ASSERT(code.ContainsInstructionAt(return_address));
+  NativeCallPattern call(return_address, code);
+  *target = call.native_function();
+  return call.target();
+}
+
+}  // namespace dart
+
+#endif  // defined TARGET_ARCH_MIPS

--- a/runtime/vm/compiler/stub_code_compiler_mips.cc
+++ b/runtime/vm/compiler/stub_code_compiler_mips.cc
@@ -401,6 +401,68 @@ void StubCodeCompiler::GenerateInvokeDartCodeStub() {
   __ LeaveFrameAndReturn();
 }
 
+// S5: Contains an ICData.
+void StubCodeCompiler::GenerateICCallBreakpointStub() {
+#if defined(PRODUCT)
+  __ Stop("No debugging in PRODUCT mode");
+#else
+  __ Comment("ICCallBreakpoint stub");
+  __ EnterStubFrame();
+  __ addiu(SP, SP, Immediate(-3 *target::kWordSize));
+  __ sw(A0, Address(SP, 2 *target::kWordSize));
+  __ sw(S5, Address(SP, 1 *target::kWordSize));
+  __ sw(ZR, Address(SP, 0 *target::kWordSize));
+
+  __ CallRuntime(kBreakpointRuntimeHandlerRuntimeEntry, 0);
+
+  __ lw(A0, Address(SP, 2 *target::kWordSize));
+  __ lw(S5, Address(SP, 1 *target::kWordSize));
+  __ lw(CODE_REG, Address(SP, 0 *target::kWordSize));
+  __ addiu(SP, SP, Immediate(3 *target::kWordSize));
+  __ LeaveStubFrame();
+  __ lw(TMP, FieldAddress(CODE_REG, Code::entry_point_offset()));
+  __ jr(TMP);
+#endif  // defined(PRODUCT)
+}
+
+// S5: ICData
+void StubCodeCompiler::GenerateUnoptStaticCallBreakpointStub() {
+#if defined(PRODUCT)
+  __ Stop("No debugging in PRODUCT mode");
+#else
+  __ EnterStubFrame();
+  __ AddImmediate(SP, SP, -2 * target::kWordSize);
+  __ sw(S5, Address(SP, 1 * target::kWordSize));  // Preserve IC data.
+  __ sw(ZR, Address(SP, 0 * target::kWordSize));  // Space for result.
+  __ CallRuntime(kBreakpointRuntimeHandlerRuntimeEntry, 0);
+  __ lw(CODE_REG, Address(SP, 0 * target::kWordSize));  // Original stub.
+  __ lw(S5, Address(SP, 1 * target::kWordSize));        // Restore IC data.
+  __ AddImmediate(SP, SP, 2 * target::kWordSize);
+  __ LeaveStubFrame();
+  __ LoadFieldFromOffset(TMP, CODE_REG, target::Code::entry_point_offset());
+  __ jr(TMP);
+#endif  // defined(PRODUCT)
+}
+
+void StubCodeCompiler::GenerateRuntimeCallBreakpointStub() {
+#if defined(PRODUCT)
+  __ Stop("No debugging in PRODUCT mode");
+#else
+  __ Comment("RuntimeCallBreakpoint stub");
+  __ EnterStubFrame();
+  __ addiu(SP, SP, Immediate(-1 *target::kWordSize));
+  __ sw(ZR, Address(SP, 0 *target::kWordSize));
+
+  __ CallRuntime(kBreakpointRuntimeHandlerRuntimeEntry, 0);
+
+  __ lw(CODE_REG, Address(SP, 0 *target::kWordSize));
+  __ addiu(SP, SP, Immediate(1 *target::kWordSize));
+  __ LeaveStubFrame();
+  __ lw(TMP, FieldAddress(CODE_REG, Code::entry_point_offset()));
+  __ jr(TMP);
+#endif  // defined(PRODUCT)
+}
+
 }  // namespace compiler
 }  // namespace dart
 

--- a/runtime/vm/debugger_mips.cc
+++ b/runtime/vm/debugger_mips.cc
@@ -1,0 +1,62 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#include "vm/globals.h"
+#if defined(TARGET_ARCH_MIPS)
+
+#include "vm/code_patcher.h"
+#include "vm/cpu.h"
+#include "vm/debugger.h"
+#include "vm/instructions.h"
+#include "vm/stub_code.h"
+
+namespace dart {
+
+#ifndef PRODUCT
+
+CodePtr CodeBreakpoint::OrigStubAddress() const {
+  return saved_value_;
+}
+
+void CodeBreakpoint::PatchCode() {
+  ASSERT(!IsEnabled());
+  Code& stub_target = Code::Handle();
+  switch (breakpoint_kind_) {
+    case UntaggedPcDescriptors::kIcCall:
+      stub_target = StubCode::ICCallBreakpoint().ptr();
+      break;
+    case UntaggedPcDescriptors::kUnoptStaticCall:
+      stub_target = StubCode::UnoptStaticCallBreakpoint().ptr();
+      break;
+    case UntaggedPcDescriptors::kRuntimeCall:
+      stub_target = StubCode::RuntimeCallBreakpoint().ptr();
+      break;
+    default:
+      UNREACHABLE();
+  }
+  const Code& code = Code::Handle(code_);
+  saved_value_ = CodePatcher::GetStaticCallTargetAt(pc_, code);
+  CodePatcher::PatchStaticCallAt(pc_, code, stub_target);
+}
+
+void CodeBreakpoint::RestoreCode() {
+  ASSERT(IsEnabled());
+  const Code& code = Code::Handle(code_);
+  switch (breakpoint_kind_) {
+    case UntaggedPcDescriptors::kIcCall:
+    case UntaggedPcDescriptors::kUnoptStaticCall:
+    case UntaggedPcDescriptors::kRuntimeCall: {
+      CodePatcher::PatchStaticCallAt(pc_, code, Code::Handle(saved_value_));
+      break;
+    }
+    default:
+      UNREACHABLE();
+  }
+}
+
+#endif  // !PRODUCT
+
+}  // namespace dart
+
+#endif  // defined TARGET_ARCH_MIPS

--- a/runtime/vm/vm_sources.gni
+++ b/runtime/vm/vm_sources.gni
@@ -92,6 +92,7 @@ vm_sources = [
   "debugger_arm.cc",
   "debugger_arm64.cc",
   "debugger_ia32.cc",
+  "debugger_mips.cc",
   "debugger_riscv.cc",
   "debugger_x64.cc",
   "deferred_objects.cc",

--- a/runtime/vm/vm_sources.gni
+++ b/runtime/vm/vm_sources.gni
@@ -44,6 +44,7 @@ vm_sources = [
   "code_patcher_arm.cc",
   "code_patcher_arm64.cc",
   "code_patcher_ia32.cc",
+  "code_patcher_mips.cc",
   "code_patcher_riscv.cc",
   "code_patcher_x64.cc",
   "constants_arm.cc",


### PR DESCRIPTION
Add implementations for code patcher, breakpoint stub generation, and debugger support.

- Implement CodePatcher supporting static, instance, switchable, and native call patching. 
- Add breakpoint stubs for IC, unopt static, and runtime calls.
- Implement CodeBreakpoint patch and restore functions, redirecting IC, unopt static, and runtime calls to breakpoint stubs.