### PR TITLE
[mips] Add flow_graph_compiler_mips.cc

### DIFF
--- a/runtime/vm/compiler/backend/flow_graph_compiler_mips.cc
+++ b/runtime/vm/compiler/backend/flow_graph_compiler_mips.cc
@@ -8,6 +8,7 @@
 #include "vm/compiler/backend/flow_graph_compiler.h"
 
 #include "vm/compiler/backend/il_printer.h"
+#include "vm/deopt_instructions.h"
 
 namespace dart {
 
@@ -36,6 +37,91 @@ void FlowGraphCompiler::EnterIntrinsicMode() {
 void FlowGraphCompiler::ExitIntrinsicMode() {
   ASSERT(intrinsic_mode());
   intrinsic_mode_ = false;
+}
+
+TypedDataPtr CompilerDeoptInfo::CreateDeoptInfo(FlowGraphCompiler* compiler,
+                                                DeoptInfoBuilder* builder,
+                                                const Array& deopt_table) {
+  if (deopt_env_ == NULL) {
+    ++builder->current_info_number_;
+    return TypedData::null();
+  }
+
+  AllocateOutgoingArguments(deopt_env_);
+
+  intptr_t slot_ix = 0;
+  Environment* current = deopt_env_;
+
+  // Emit all kMaterializeObject instructions describing objects to be
+  // materialized on the deoptimization as a prefix to the deoptimization info.
+  EmitMaterializations(deopt_env_, builder);
+
+  // The real frame starts here.
+  builder->MarkFrameStart();
+
+  Zone* zone = compiler->zone();
+
+  builder->AddPp(current->function(), slot_ix++);
+  builder->AddPcMarker(Function::ZoneHandle(zone), slot_ix++);
+  builder->AddCallerFp(slot_ix++);
+  builder->AddReturnAddress(current->function(), deopt_id(), slot_ix++);
+
+  // Emit all values that are needed for materialization as a part of the
+  // expression stack for the bottom-most frame. This guarantees that GC
+  // will be able to find them during materialization.
+  slot_ix = builder->EmitMaterializationArguments(slot_ix);
+
+  // For the innermost environment, set outgoing arguments and the locals.
+  for (intptr_t i = current->Length() - 1;
+       i >= current->fixed_parameter_count(); i--) {
+    builder->AddCopy(current->ValueAt(i), current->LocationAt(i), slot_ix++);
+  }
+
+  Environment* previous = current;
+  current = current->outer();
+  while (current != nullptr) {
+    builder->AddPp(current->function(), slot_ix++);
+    builder->AddPcMarker(previous->function(), slot_ix++);
+    builder->AddCallerFp(slot_ix++);
+
+    // For any outer environment the deopt id is that of the call instruction
+    // which is recorded in the outer environment.
+    builder->AddReturnAddress(current->function(),
+                              DeoptId::ToDeoptAfter(current->GetDeoptId()),
+                              slot_ix++);
+
+    // The values of outgoing arguments can be changed from the inlined call so
+    // we must read them from the previous environment.
+    for (intptr_t i = previous->fixed_parameter_count() - 1; i >= 0; i--) {
+      builder->AddCopy(previous->ValueAt(i), previous->LocationAt(i),
+                       slot_ix++);
+    }
+
+    // Set the locals, note that outgoing arguments are not in the environment.
+    for (intptr_t i = current->Length() - 1;
+         i >= current->fixed_parameter_count(); i--) {
+      builder->AddCopy(current->ValueAt(i), current->LocationAt(i), slot_ix++);
+    }
+
+    // Iterate on the outer environment.
+    previous = current;
+    current = current->outer();
+  }
+  // The previous pointer is now the outermost environment.
+  ASSERT(previous != nullptr);
+
+  // Set slots for the outermost environment.
+  builder->AddCallerPp(slot_ix++);
+  builder->AddPcMarker(previous->function(), slot_ix++);
+  builder->AddCallerFp(slot_ix++);
+  builder->AddCallerPc(slot_ix++);
+
+  // For the outermost environment, set the incoming arguments.
+  for (intptr_t i = previous->fixed_parameter_count() - 1; i >= 0; i--) {
+    builder->AddCopy(previous->ValueAt(i), previous->LocationAt(i), slot_ix++);
+  }
+
+  return builder->CreateDeoptInfo(deopt_table);
 }
 
 #define __ assembler()->

--- a/runtime/vm/compiler/backend/flow_graph_compiler_mips.cc
+++ b/runtime/vm/compiler/backend/flow_graph_compiler_mips.cc
@@ -11,6 +11,17 @@
 
 namespace dart {
 
+void FlowGraphCompiler::EnterIntrinsicMode() {
+  ASSERT(!intrinsic_mode());
+  intrinsic_mode_ = true;
+  ASSERT(!assembler()->constant_pool_allowed());
+}
+
+void FlowGraphCompiler::ExitIntrinsicMode() {
+  ASSERT(intrinsic_mode());
+  intrinsic_mode_ = false;
+}
+
 #define __ assembler()->
 
 void FlowGraphCompiler::EmitCallToStub(

--- a/runtime/vm/compiler/backend/flow_graph_compiler_mips.cc
+++ b/runtime/vm/compiler/backend/flow_graph_compiler_mips.cc
@@ -77,6 +77,20 @@ void FlowGraphCompiler::EmitTailCallToStub(const Code& stub) {
   }
 }
 
+// This function must be in sync with FlowGraphCompiler::RecordSafepoint and
+// FlowGraphCompiler::SlowPathEnvironmentFor.
+void FlowGraphCompiler::SaveLiveRegisters(LocationSummary* locs) {
+#if defined(DEBUG)
+  locs->CheckWritableInputs();
+  ClobberDeadTempRegisters(locs);
+#endif
+  __ PushRegisters(*locs->live_registers());
+}
+
+void FlowGraphCompiler::RestoreLiveRegisters(LocationSummary* locs) {
+  __ PopRegisters(*locs->live_registers());
+}
+
 #undef __
 
 }  // namespace dart

--- a/runtime/vm/compiler/backend/flow_graph_compiler_mips.cc
+++ b/runtime/vm/compiler/backend/flow_graph_compiler_mips.cc
@@ -1,0 +1,57 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#include "vm/globals.h"  // Needed here to get TARGET_ARCH_MIPS.
+#if defined(TARGET_ARCH_MIPS)
+
+#include "vm/compiler/backend/flow_graph_compiler.h"
+
+#include "vm/compiler/backend/il_printer.h"
+
+namespace dart {
+
+#define __ assembler()->
+
+void FlowGraphCompiler::EmitCallToStub(
+    const Code& stub,
+    ObjectPool::SnapshotBehavior snapshot_behavior) {
+  ASSERT(!stub.IsNull());
+  if (CanPcRelativeCall(stub)) {
+    __ GenerateUnRelocatedPcRelativeCall();
+    AddPcRelativeCallStubTarget(stub);
+  } else {
+    __ JumpAndLink(stub, compiler::ObjectPoolBuilderEntry::kNotPatchable,
+                   CodeEntryKind::kNormal, snapshot_behavior);
+    AddStubCallTarget(stub);
+  }
+}
+
+void FlowGraphCompiler::EmitTailCallToStub(const Code& stub) {
+  ASSERT(!stub.IsNull());
+  if (CanPcRelativeCall(stub)) {
+    if (flow_graph().graph_entry()->NeedsFrame()) {
+      __ LeaveDartFrame();
+    }
+    __ GenerateUnRelocatedPcRelativeTailCall();
+    AddPcRelativeTailCallStubTarget(stub);
+#if defined(DEBUG)
+    __ Breakpoint();
+#endif
+  } else {
+    __ LoadObject(CODE_REG, stub);
+    if (flow_graph().graph_entry()->NeedsFrame()) {
+      __ LeaveDartFrame();
+    }
+    __ lw(TMP, compiler::FieldAddress(
+                   CODE_REG, compiler::target::Code::entry_point_offset()));
+    __ jr(TMP);
+    AddStubCallTarget(stub);
+  }
+}
+
+#undef __
+
+}  // namespace dart
+
+#endif  // defined(TARGET_ARCH_MIPS)

--- a/runtime/vm/compiler/backend/flow_graph_compiler_mips.cc
+++ b/runtime/vm/compiler/backend/flow_graph_compiler_mips.cc
@@ -163,6 +163,67 @@ void FlowGraphCompiler::EmitTailCallToStub(const Code& stub) {
   }
 }
 
+void FlowGraphCompiler::EmitInstanceCallJIT(const Code& stub,
+                                            const ICData& ic_data,
+                                            intptr_t deopt_id,
+                                            const InstructionSource& source,
+                                            LocationSummary* locs,
+                                            Code::EntryKind entry_kind) {
+  ASSERT(CanCallDart());
+  ASSERT(entry_kind == Code::EntryKind::kNormal ||
+         entry_kind == Code::EntryKind::kUnchecked);
+  ASSERT(Array::Handle(zone(), ic_data.arguments_descriptor()).Length() > 0);
+  __ LoadFromOffset(A0, SP, (ic_data.SizeWithoutTypeArgs() - 1) * kWordSize);
+  __ LoadUniqueObject(S5, ic_data);
+  __ LoadUniqueObject(CODE_REG, stub);
+  const intptr_t entry_point_offset =
+      entry_kind == Code::EntryKind::kNormal
+          ? Code::entry_point_offset(Code::EntryKind::kMonomorphic)
+          : Code::entry_point_offset(Code::EntryKind::kMonomorphicUnchecked);
+  __ lw(T9, compiler::FieldAddress(CODE_REG, entry_point_offset));
+  __ jalr(T9);
+  EmitCallsiteMetadata(source, deopt_id, UntaggedPcDescriptors::kIcCall, locs,
+                       pending_deoptimization_env_);
+  EmitDropArguments(ic_data.SizeWithTypeArgs());
+}
+
+void FlowGraphCompiler::EmitInstanceCallAOT(const ICData& ic_data,
+                                            intptr_t deopt_id,
+                                            const InstructionSource& source,
+                                            LocationSummary* locs,
+                                            Code::EntryKind entry_kind,
+                                            bool receiver_can_be_smi) {
+  ASSERT(CanCallDart());
+  ASSERT(entry_kind == Code::EntryKind::kNormal ||
+         entry_kind == Code::EntryKind::kUnchecked);
+  ASSERT(ic_data.NumArgsTested() == 1);
+  const Code& initial_stub = StubCode::SwitchableCallMiss();
+  const char* switchable_call_mode = "smiable";
+  if (!receiver_can_be_smi) {
+    switchable_call_mode = "non-smi";
+    ic_data.set_receiver_cannot_be_smi(true);
+  }
+  const UnlinkedCall& data =
+      UnlinkedCall::ZoneHandle(zone(), ic_data.AsUnlinkedCall());
+
+  __ Comment("InstanceCallAOT (%s)", switchable_call_mode);
+  __ LoadImmediate(ARGS_DESC_REG, 0);
+  __ lw(A0,
+        compiler::Address(SP, (ic_data.SizeWithoutTypeArgs() - 1) * compiler::target::kWordSize));
+  // The AOT runtime will replace the slot in the object pool with the
+  // entrypoint address - see app_snapshot.cc.
+  const auto snapshot_behavior =
+      compiler::ObjectPoolBuilderEntry::kResetToSwitchableCallMissEntryPoint;
+
+  __ LoadUniqueObject(T9, initial_stub, snapshot_behavior);
+  __ LoadUniqueObject(ICREG, data);
+  __ jalr(T9);
+
+  EmitCallsiteMetadata(source, deopt_id, UntaggedPcDescriptors::kOther, locs,
+                       pending_deoptimization_env_);
+  EmitDropArguments(ic_data.SizeWithTypeArgs());
+}
+
 // This function must be in sync with FlowGraphCompiler::RecordSafepoint and
 // FlowGraphCompiler::SlowPathEnvironmentFor.
 void FlowGraphCompiler::SaveLiveRegisters(LocationSummary* locs) {

--- a/runtime/vm/compiler/backend/flow_graph_compiler_mips.cc
+++ b/runtime/vm/compiler/backend/flow_graph_compiler_mips.cc
@@ -11,6 +11,22 @@
 
 namespace dart {
 
+FlowGraphCompiler::~FlowGraphCompiler() {
+  // BlockInfos are zone-allocated, so their destructors are not called.
+  // Verify the labels explicitly here.
+  for (int i = 0; i < block_info_.length(); ++i) {
+    ASSERT(!block_info_[i]->jump_label()->IsLinked());
+  }
+}
+
+bool FlowGraphCompiler::SupportsUnboxedSimd128() {
+  return false;
+}
+
+bool FlowGraphCompiler::CanConvertInt64ToDouble() {
+  return false;
+}
+
 void FlowGraphCompiler::EnterIntrinsicMode() {
   ASSERT(!intrinsic_mode());
   intrinsic_mode_ = true;

--- a/runtime/vm/compiler/compiler_sources.gni
+++ b/runtime/vm/compiler/compiler_sources.gni
@@ -59,6 +59,7 @@ compiler_sources = [
   "backend/flow_graph_compiler_arm.cc",
   "backend/flow_graph_compiler_arm64.cc",
   "backend/flow_graph_compiler_ia32.cc",
+  "backend/flow_graph_compiler_mips.cc",
   "backend/flow_graph_compiler_riscv.cc",
   "backend/flow_graph_compiler_x64.cc",
   "backend/il.cc",


### PR DESCRIPTION
This PR introduces a new file, flow_graph_compiler_mips.cc, which contains MIPS-specific functions for the FlowGraphCompiler class. These functions:

- SupportsUnboxedSimd128
- CanConvertInt64ToDouble
- EnterIntrinsicMode
- ExitIntrinsicMode
- CreateDeoptInfo
- EmitCallToStub
- EmitTailCallToStub
- EmitInstanceCallJIT
- EmitInstanceCallAOT
- SaveLiveRegisters
- RestoreLiveRegisters