### PR TITLE
[mips] Add instruction patterns, branch-link implementations, and ABI updates

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -492,7 +492,7 @@ if (is_fuchsia) {
   }
 }
 
-if (is_linux && current_cpu != "riscv32 && current_cpu != "mipsel") {
+if (is_linux && current_cpu != "riscv32" && current_cpu != "mipsel") {
   #TODO: Handle MIPS.
   group("debian_package") {
     public_deps = [ "tools/debian_package" ]

--- a/runtime/vm/code_patcher_mips.cc
+++ b/runtime/vm/code_patcher_mips.cc
@@ -27,10 +27,6 @@ void CodePatcher::PatchStaticCallAt(uword return_address,
   call.SetTargetCode(new_target);
 }
 
-void CodePatcher::InsertDeoptimizationCallAt(uword start) {
-  UNREACHABLE();
-}
-
 CodePtr CodePatcher::GetInstanceCallAt(uword return_address,
                                        const Code& code,
                                        Object* ic_data) {
@@ -82,28 +78,22 @@ void CodePatcher::PatchSwitchableCallAt(uword return_address,
                                         const Code& caller_code,
                                         const Object& data,
                                         const Code& target) {
-  auto thread = Thread::Current();
-  // Ensure all threads are suspended as we update data and target pair.
-  thread->isolate_group()->RunWithStoppedMutators([&]() {
-    PatchSwitchableCallAtWithMutatorsStopped(thread, return_address,
-                                             caller_code, data, target);
-  });
-}
-
-void CodePatcher::PatchSwitchableCallAtWithMutatorsStopped(
-    Thread* thread,
-    uword return_address,
-    const Code& caller_code,
-    const Object& data,
-    const Code& target) {
+  // We lock to block other writers but don't start a safepoint to block readers
+  // (i.e., Dart execution).
+  // First update target to a stub that does not read 'data' so that concurrent
+  // Dart execution cannot observe the new stub with the old data or the old
+  // stub with the new data.
+  SafepointMutexLocker ml(IsolateGroup::Current()->type_feedback_mutex());
   if (FLAG_precompiled_mode) {
     BareSwitchableCallPattern call(return_address);
-    call.SetData(data);
-    call.SetTarget(target);
+    call.SetTargetRelease(StubCode::SwitchableCallMiss());
+    call.SetDataRelease(data);
+    call.SetTargetRelease(target);
   } else {
     SwitchableCallPattern call(return_address, caller_code);
-    call.SetData(data);
-    call.SetTarget(target);
+    call.SetTargetRelease(StubCode::SwitchableCallMiss());
+    call.SetDataRelease(data);
+    call.SetTargetRelease(target);
   }
 }
 
@@ -113,8 +103,7 @@ uword CodePatcher::GetSwitchableCallTargetEntryAt(uword return_address,
     BareSwitchableCallPattern call(return_address);
     return call.target_entry();
   } else {
-    SwitchableCallPattern call(return_address, caller_code);
-    return call.target_entry();
+    UNREACHABLE();
   }
 }
 

--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -666,7 +666,8 @@ void Assembler::JumpAndLink(
 //   S5 : address of the runtime function to call.
 //   S4 : number of arguments to the call.
 void Assembler::CallRuntime(const RuntimeEntry& entry,
-                            intptr_t argument_count) {
+                            intptr_t argument_count,
+                            bool tsan_enter_exit) {
   ASSERT(!entry.is_leaf());
   // Argument count is not checked here, but in the runtime entry for a more
   // informative error message.

--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -409,6 +409,54 @@ void Assembler::SetIf(Condition condition, Register rd) {
   deferred_compare_ = kNone;
 }
 
+void Assembler::BranchLink(
+    const Code& target,
+    ObjectPoolBuilderEntry::Patchability patchable,
+    CodeEntryKind entry_kind,
+    ObjectPoolBuilderEntry::SnapshotBehavior snapshot_behavior) {
+  ASSERT(!in_delay_slot_);
+  const intptr_t index = object_pool_builder().FindObject(
+      ToObject(target), patchable, snapshot_behavior);
+  // Avoid clobbering CODE_REG when invoking code in precompiled mode.
+  // We don't actually use CODE_REG in the callee and caller might
+  // be using CODE_REG for a live value (e.g. a value that is alive
+  // across invocation of a shared stub like the one we use for
+  // allocating Mint boxes).
+  const Register code_reg = FLAG_precompiled_mode ? TMP : CODE_REG;
+  LoadWordFromPoolIndex(code_reg, index);
+  lw(T9, FieldAddress(code_reg, target::Code::entry_point_offset(entry_kind)));
+  jalr(T9);
+  if (patchable == ObjectPoolBuilderEntry::kPatchable) {
+    delay_slot_available_ = false;  // CodePatcher expects a nop.
+  }
+}
+
+void Assembler::BranchLinkPatchable(
+    const Code& code,
+    CodeEntryKind entry_kind,
+    ObjectPoolBuilderEntry::SnapshotBehavior snapshot_behavior) {
+  BranchLink(code, ObjectPoolBuilderEntry::kPatchable, entry_kind,
+             snapshot_behavior);
+}
+
+void Assembler::BranchLinkWithEquivalence(const Code& target,
+                                          const Object& equivalence,
+                                          CodeEntryKind entry_kind) {
+  ASSERT(!in_delay_slot_);
+  const intptr_t index =
+      object_pool_builder().FindObject(ToObject(target), equivalence);
+  // Avoid clobbering CODE_REG when invoking code in precompiled mode.
+  // We don't actually use CODE_REG in the callee and caller might
+  // be using CODE_REG for a live value (e.g. a value that is alive
+  // across invocation of a shared stub like the one we use for
+  // allocating Mint boxes).
+  const Register code_reg = FLAG_precompiled_mode ? TMP : CODE_REG;
+  LoadWordFromPoolIndex(code_reg, index);
+  lw(T9, FieldAddress(code_reg, target::Code::entry_point_offset(entry_kind)));
+  jalr(T9);
+  delay_slot_available_ = false;  // CodePatcher expects a nop.
+}
+
 void Assembler::Bind(Label* label) {
   UNIMPLEMENTED();
 }

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -948,6 +948,27 @@ class Assembler : public AssemblerBase {
     bne(CMPRES1, ZR, label);
   }
 
+  void BranchLink(const Code& code,
+                  ObjectPoolBuilderEntry::Patchability patchable =
+                      ObjectPoolBuilderEntry::kNotPatchable,
+                  CodeEntryKind entry_kind = CodeEntryKind::kNormal,
+                  ObjectPoolBuilderEntry::SnapshotBehavior snapshot_behavior =
+                      ObjectPoolBuilderEntry::kSnapshotable);
+
+  // Branch and link to an entry address. Call sequence can be patched.
+  void BranchLinkPatchable(
+      const Code& code,
+      CodeEntryKind entry_kind = CodeEntryKind::kNormal,
+      ObjectPoolBuilderEntry::SnapshotBehavior snapshot_behavior =
+          ObjectPoolBuilderEntry::kSnapshotable);
+
+  // Emit a call that shares its object pool entries with other calls
+  // that have the same equivalence marker.
+  void BranchLinkWithEquivalence(
+      const Code& code,
+      const Object& equivalence,
+      CodeEntryKind entry_kind = CodeEntryKind::kNormal);
+
   void Bind(Label* label) override;
 
   // Unconditional jump to a given label. [distance] is ignored on MIPS.

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -986,6 +986,9 @@ class Assembler : public AssemblerBase {
     StoreToOffset(src, base, offset);
   }
 
+  void TsanFuncEntry(bool preserve_registers = true) { UNREACHABLE(); }
+  void TsanFuncExit(bool preserve_registers = true) { UNREACHABLE(); }
+
   Address PrepareLargeOffset(Register base, int32_t offset);
 
   void LoadObjectHelper(Register rd, const Object& object, bool is_unique,
@@ -1096,7 +1099,9 @@ class Assembler : public AssemblerBase {
                    ObjectPoolBuilderEntry::SnapshotBehavior snapshot_behavior =
                        ObjectPoolBuilderEntry::kSnapshotable);
 
-  void CallRuntime(const RuntimeEntry& entry, intptr_t argument_count);
+  void CallRuntime(const RuntimeEntry& entry,
+                   intptr_t argument_count,
+                   bool tsan_enter_exit = true);
   
   void LoadPoolPointer(Register reg = PP);
   void CheckCodePointer();

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -365,6 +365,8 @@ class Assembler : public AssemblerBase {
 
   void Breakpoint() override { break_(0); }
 
+  void StoreStoreFence() override { sync(0); }
+
   // FPU compare, always false.
   void cfd(DRegister ds, DRegister dt) {
     FRegister fs = static_cast<FRegister>(ds * 2);
@@ -1102,6 +1104,14 @@ class Assembler : public AssemblerBase {
   void CallRuntime(const RuntimeEntry& entry,
                    intptr_t argument_count,
                    bool tsan_enter_exit = true);
+
+  void CallCFunction(Address target) { Call(target); }
+  void CallCFunction(Register target) {
+    if (target != T9) {
+      mov(T9, target);
+    }
+    Call(T9);
+  }
   
   void LoadPoolPointer(Register reg = PP);
   void CheckCodePointer();

--- a/runtime/vm/compiler/runtime_offsets_extracted.h
+++ b/runtime/vm/compiler/runtime_offsets_extracted.h
@@ -6126,6 +6126,8 @@ static constexpr dart::compiler::target::word Array_kMaxElements = 0xfffffff;
 static constexpr dart::compiler::target::word Array_kMaxNewSpaceElements =
     0xfffd;
 static constexpr dart::compiler::target::word Context_kMaxElements = 0xfffffff;
+static constexpr dart::compiler::target::word Heap_kNewAllocatableSize =
+    0x40000;
 static constexpr dart::compiler::target::word
     Instructions_kMonomorphicEntryOffsetJIT = 0xc;
 static constexpr dart::compiler::target::word
@@ -6141,6 +6143,7 @@ static constexpr dart::compiler::target::word
 static constexpr dart::compiler::target::word
     NativeEntry_kNumCallWrapperArguments = 0x2;
 static constexpr dart::compiler::target::word Page_kBytesPerCardLog2 = 0x7;
+static constexpr dart::compiler::target::word Page_kPageMask = -0x80000;
 static constexpr dart::compiler::target::word Record_kMaxElements = 0xffff;
 static constexpr dart::compiler::target::word RecordShape_kFieldNamesIndexMask =
     0x3fff;
@@ -6178,6 +6181,34 @@ static constexpr dart::compiler::target::word SubtypeTestCache_kTestResult =
     0x7;
 static constexpr dart::compiler::target::word TypeArguments_kMaxElements =
     0xfffffff;
+static constexpr dart::compiler::target::word
+    UntaggedObject_kCardRememberedBit = 0x0;
+static constexpr dart::compiler::target::word UntaggedObject_kCanonicalBit =
+    0x1;
+static constexpr dart::compiler::target::word UntaggedObject_kNotMarkedBit =
+    0x2;
+static constexpr dart::compiler::target::word
+    UntaggedObject_kNewOrEvacuationCandidateBit = 0x3;
+static constexpr dart::compiler::target::word UntaggedObject_kAlwaysSetBit =
+    0x4;
+static constexpr dart::compiler::target::word
+    UntaggedObject_kOldAndNotRememberedBit = 0x5;
+static constexpr dart::compiler::target::word
+    UntaggedObject_kIncrementalBarrierMask = 0x4;
+static constexpr dart::compiler::target::word
+    UntaggedObject_kGenerationalBarrierMask = 0x8;
+static constexpr dart::compiler::target::word
+    UntaggedObject_kBarrierOverlapShift = 0x2;
+static constexpr dart::compiler::target::word
+    UntaggedObject_kShallowImmutableBit = 0x6;
+static constexpr dart::compiler::target::word
+    UntaggedObject_kDeeplyImmutableBit = 0x7;
+static constexpr dart::compiler::target::word UntaggedObject_kSizeTagPos = 0x8;
+static constexpr dart::compiler::target::word UntaggedObject_kSizeTagSize = 0x4;
+static constexpr dart::compiler::target::word UntaggedObject_kClassIdTagPos =
+    0xc;
+static constexpr dart::compiler::target::word UntaggedObject_kClassIdTagSize =
+    0x14;
 static constexpr dart::compiler::target::word AbstractType_flags_offset = 0x8;
 static constexpr dart::compiler::target::word AbstractType_hash_offset = 0x10;
 static constexpr dart::compiler::target::word
@@ -6235,13 +6266,13 @@ static constexpr dart::compiler::target::word
     Field_initializer_function_offset = 0x10;
 static constexpr dart::compiler::target::word
     Field_host_offset_or_field_id_offset = 0x14;
-static constexpr dart::compiler::target::word Field_guarded_cid_offset = 0x28;
+static constexpr dart::compiler::target::word Field_guarded_cid_offset = 0x2c;
 static constexpr dart::compiler::target::word
-    Field_guarded_list_length_in_object_offset_offset = 0x34;
+    Field_guarded_list_length_in_object_offset_offset = 0x38;
 static constexpr dart::compiler::target::word Field_guarded_list_length_offset =
     0x18;
-static constexpr dart::compiler::target::word Field_is_nullable_offset = 0x2c;
-static constexpr dart::compiler::target::word Field_kind_bits_offset = 0x36;
+static constexpr dart::compiler::target::word Field_is_nullable_offset = 0x30;
+static constexpr dart::compiler::target::word Field_kind_bits_offset = 0x3c;
 static constexpr dart::compiler::target::word Function_code_offset = 0x20;
 static constexpr dart::compiler::target::word Function_data_offset = 0x18;
 static constexpr dart::compiler::target::word Function_entry_point_offset[] = {
@@ -6266,19 +6297,17 @@ static constexpr dart::compiler::target::word ICData_NumArgsTestedShift = 0x0;
 static constexpr dart::compiler::target::word ICData_entries_offset = 0xc;
 static constexpr dart::compiler::target::word ICData_owner_offset = 0x14;
 static constexpr dart::compiler::target::word ICData_state_bits_offset = 0x1c;
+static constexpr dart::compiler::target::word Instance_first_field_offset = 0x4;
 static constexpr dart::compiler::target::word Int32x4_value_offset = 0x8;
-static constexpr dart::compiler::target::word Isolate_current_tag_offset = 0xc;
-static constexpr dart::compiler::target::word Isolate_default_tag_offset = 0x10;
-static constexpr dart::compiler::target::word Isolate_finalizers_offset = 0x18;
+static constexpr dart::compiler::target::word Isolate_finalizers_offset = 0xc;
 static constexpr dart::compiler::target::word
-    Isolate_has_resumption_breakpoints_offset = 0x1c;
+    Isolate_has_resumption_breakpoints_offset = 0x10;
 static constexpr dart::compiler::target::word IsolateGroup_object_store_offset =
     0x10;
 static constexpr dart::compiler::target::word IsolateGroup_class_table_offset =
     0x8;
 static constexpr dart::compiler::target::word
     IsolateGroup_cached_class_table_table_offset = 0xc;
-static constexpr dart::compiler::target::word Isolate_user_tag_offset = 0x8;
 static constexpr dart::compiler::target::word LinkedHashBase_data_offset = 0xc;
 static constexpr dart::compiler::target::word
     ImmutableLinkedHashBase_data_offset = 0xc;
@@ -6309,40 +6338,41 @@ static constexpr dart::compiler::target::word NativeArguments_retval_offset =
     0xc;
 static constexpr dart::compiler::target::word NativeArguments_thread_offset =
     0x0;
+static constexpr dart::compiler::target::word Object_tags_offset = 0x0;
 static constexpr dart::compiler::target::word ObjectStore_double_type_offset =
-    0xc0;
+    0xdc;
 static constexpr dart::compiler::target::word ObjectStore_int_type_offset =
-    0x98;
+    0xb4;
 static constexpr dart::compiler::target::word
-    ObjectStore_record_field_names_offset = 0x1f8;
+    ObjectStore_record_field_names_offset = 0x218;
 static constexpr dart::compiler::target::word ObjectStore_string_type_offset =
-    0xd4;
+    0xf0;
 static constexpr dart::compiler::target::word ObjectStore_type_type_offset =
-    0x84;
+    0xa0;
 static constexpr dart::compiler::target::word
-    ObjectStore_ffi_callback_code_offset = 0x274;
+    ObjectStore_ffi_callback_code_offset = 0x294;
 static constexpr dart::compiler::target::word
-    ObjectStore_suspend_state_await_offset = 0x220;
+    ObjectStore_suspend_state_await_offset = 0x240;
 static constexpr dart::compiler::target::word
-    ObjectStore_suspend_state_await_with_type_check_offset = 0x224;
+    ObjectStore_suspend_state_await_with_type_check_offset = 0x244;
 static constexpr dart::compiler::target::word
-    ObjectStore_suspend_state_handle_exception_offset = 0x244;
+    ObjectStore_suspend_state_handle_exception_offset = 0x264;
 static constexpr dart::compiler::target::word
-    ObjectStore_suspend_state_init_async_offset = 0x21c;
+    ObjectStore_suspend_state_init_async_offset = 0x23c;
 static constexpr dart::compiler::target::word
-    ObjectStore_suspend_state_init_async_star_offset = 0x230;
+    ObjectStore_suspend_state_init_async_star_offset = 0x250;
 static constexpr dart::compiler::target::word
-    ObjectStore_suspend_state_init_sync_star_offset = 0x23c;
+    ObjectStore_suspend_state_init_sync_star_offset = 0x25c;
 static constexpr dart::compiler::target::word
-    ObjectStore_suspend_state_return_async_offset = 0x228;
+    ObjectStore_suspend_state_return_async_offset = 0x248;
 static constexpr dart::compiler::target::word
-    ObjectStore_suspend_state_return_async_not_future_offset = 0x22c;
+    ObjectStore_suspend_state_return_async_not_future_offset = 0x24c;
 static constexpr dart::compiler::target::word
-    ObjectStore_suspend_state_return_async_star_offset = 0x238;
+    ObjectStore_suspend_state_return_async_star_offset = 0x258;
 static constexpr dart::compiler::target::word
-    ObjectStore_suspend_state_suspend_sync_star_at_start_offset = 0x240;
+    ObjectStore_suspend_state_suspend_sync_star_at_start_offset = 0x260;
 static constexpr dart::compiler::target::word
-    ObjectStore_suspend_state_yield_async_star_offset = 0x234;
+    ObjectStore_suspend_state_yield_async_star_offset = 0x254;
 static constexpr dart::compiler::target::word OneByteString_data_offset = 0xc;
 static constexpr dart::compiler::target::word PersistentHandle_ptr_offset = 0x0;
 static constexpr dart::compiler::target::word PointerBase_data_offset = 0x4;
@@ -6385,53 +6415,51 @@ static constexpr dart::compiler::target::word
     SuspendState_then_callback_offset = 0x14;
 static constexpr dart::compiler::target::word
     Thread_AllocateArray_entry_point_offset = 0x174;
+static constexpr dart::compiler::target::word
+    Thread_DeoptimizeCopyFrame_entry_point_offset = 0x380;
 static constexpr dart::compiler::target::word Thread_active_exception_offset =
-    0x3e8;
+    0x360;
 static constexpr dart::compiler::target::word Thread_active_stacktrace_offset =
-    0x3ec;
+    0x364;
 static constexpr dart::compiler::target::word
     Thread_array_write_barrier_entry_point_offset = 0x100;
 static constexpr dart::compiler::target::word
     Thread_allocate_mint_with_fpu_regs_entry_point_offset = 0x108;
 static constexpr dart::compiler::target::word
-    Thread_allocate_mint_with_fpu_regs_stub_offset = 0x9c;
+    Thread_allocate_mint_with_fpu_regs_stub_offset = 0xa8;
 static constexpr dart::compiler::target::word
     Thread_allocate_mint_without_fpu_regs_entry_point_offset = 0x10c;
 static constexpr dart::compiler::target::word
-    Thread_allocate_mint_without_fpu_regs_stub_offset = 0xa0;
+    Thread_allocate_mint_without_fpu_regs_stub_offset = 0xac;
 static constexpr dart::compiler::target::word
     Thread_allocate_object_entry_point_offset = 0x110;
 static constexpr dart::compiler::target::word
-    Thread_allocate_object_stub_offset = 0xa4;
-static constexpr dart::compiler::target::word
     Thread_allocate_object_parameterized_entry_point_offset = 0x114;
 static constexpr dart::compiler::target::word
-    Thread_allocate_object_parameterized_stub_offset = 0xa8;
-static constexpr dart::compiler::target::word
     Thread_allocate_object_slow_entry_point_offset = 0x118;
-static constexpr dart::compiler::target::word
-    Thread_allocate_object_slow_stub_offset = 0xac;
 static constexpr dart::compiler::target::word Thread_api_top_scope_offset =
-    0x408;
+    0x440;
 static constexpr dart::compiler::target::word
     Thread_async_exception_handler_stub_offset = 0xb0;
 static constexpr dart::compiler::target::word
     Thread_auto_scope_native_wrapper_entry_point_offset = 0x14c;
-static constexpr dart::compiler::target::word Thread_bool_false_offset = 0x40;
-static constexpr dart::compiler::target::word Thread_bool_true_offset = 0x3c;
+static constexpr dart::compiler::target::word Thread_bool_false_offset = 0x4c;
+static constexpr dart::compiler::target::word Thread_bool_true_offset = 0x48;
 static constexpr dart::compiler::target::word
     Thread_bootstrap_native_wrapper_entry_point_offset = 0x144;
 static constexpr dart::compiler::target::word
     Thread_call_to_runtime_entry_point_offset = 0x104;
 static constexpr dart::compiler::target::word
-    Thread_call_to_runtime_stub_offset = 0x60;
-static constexpr dart::compiler::target::word Thread_dart_stream_offset = 0x430;
+    Thread_call_to_runtime_stub_offset = 0x6c;
+static constexpr dart::compiler::target::word Thread_dart_stream_offset = 0x47c;
 static constexpr dart::compiler::target::word
-    Thread_dispatch_table_array_offset = 0x2c;
+    Thread_dispatch_table_array_offset = 0x34;
 static constexpr dart::compiler::target::word
-    Thread_double_truncate_round_supported_offset = 0x40c;
+    Thread_double_truncate_round_supported_offset = 0x444;
 static constexpr dart::compiler::target::word
-    Thread_service_extension_stream_offset = 0x434;
+    Thread_service_extension_stream_offset = 0x480;
+static constexpr dart::compiler::target::word Thread_thread_locals_offset =
+    0x484;
 static constexpr dart::compiler::target::word Thread_optimize_entry_offset =
     0x12c;
 static constexpr dart::compiler::target::word Thread_optimize_stub_offset =
@@ -6444,11 +6472,11 @@ static constexpr dart::compiler::target::word Thread_double_abs_address_offset =
     0x160;
 static constexpr dart::compiler::target::word
     Thread_double_negate_address_offset = 0x15c;
-static constexpr dart::compiler::target::word Thread_end_offset = 0x28;
+static constexpr dart::compiler::target::word Thread_end_offset = 0x30;
 static constexpr dart::compiler::target::word
     Thread_enter_safepoint_stub_offset = 0xf0;
 static constexpr dart::compiler::target::word Thread_execution_state_offset =
-    0x3fc;
+    0x374;
 static constexpr dart::compiler::target::word
     Thread_exit_safepoint_stub_offset = 0xf4;
 static constexpr dart::compiler::target::word
@@ -6456,9 +6484,9 @@ static constexpr dart::compiler::target::word
 static constexpr dart::compiler::target::word
     Thread_call_native_through_safepoint_entry_point_offset = 0x134;
 static constexpr dart::compiler::target::word
-    Thread_fix_allocation_stub_code_offset = 0x54;
+    Thread_fix_allocation_stub_code_offset = 0x60;
 static constexpr dart::compiler::target::word
-    Thread_fix_callers_target_code_offset = 0x50;
+    Thread_fix_callers_target_code_offset = 0x5c;
 static constexpr dart::compiler::target::word
     Thread_float_absolute_address_offset = 0x16c;
 static constexpr dart::compiler::target::word
@@ -6468,20 +6496,20 @@ static constexpr dart::compiler::target::word Thread_float_not_address_offset =
 static constexpr dart::compiler::target::word
     Thread_float_zerow_address_offset = 0x170;
 static constexpr dart::compiler::target::word Thread_global_object_pool_offset =
-    0x3f0;
+    0x368;
 static constexpr dart::compiler::target::word
     Thread_interpret_call_entry_point_offset = 0x150;
 static constexpr dart::compiler::target::word
-    Thread_invoke_dart_code_from_bytecode_stub_offset = 0x5c;
+    Thread_invoke_dart_code_from_bytecode_stub_offset = 0x68;
 static constexpr dart::compiler::target::word
-    Thread_invoke_dart_code_stub_offset = 0x58;
+    Thread_invoke_dart_code_stub_offset = 0x64;
 static constexpr dart::compiler::target::word Thread_exit_through_ffi_offset =
-    0x404;
-static constexpr dart::compiler::target::word Thread_isolate_offset = 0x3b0;
+    0x37c;
+static constexpr dart::compiler::target::word Thread_isolate_offset = 0x338;
 static constexpr dart::compiler::target::word Thread_isolate_group_offset =
-    0x3b4;
+    0x33c;
 static constexpr dart::compiler::target::word Thread_field_table_values_offset =
-    0x30;
+    0x38;
 static constexpr dart::compiler::target::word
     Thread_lazy_deopt_from_return_stub_offset = 0xe0;
 static constexpr dart::compiler::target::word
@@ -6489,9 +6517,9 @@ static constexpr dart::compiler::target::word
 static constexpr dart::compiler::target::word
     Thread_lazy_specialize_type_test_stub_offset = 0xec;
 static constexpr dart::compiler::target::word
-    Thread_old_marking_stack_block_offset = 0x3c8;
+    Thread_old_marking_stack_block_offset = 0x350;
 static constexpr dart::compiler::target::word
-    Thread_new_marking_stack_block_offset = 0x3cc;
+    Thread_new_marking_stack_block_offset = 0x354;
 static constexpr dart::compiler::target::word
     Thread_megamorphic_call_checked_entry_offset = 0x124;
 static constexpr dart::compiler::target::word
@@ -6501,33 +6529,33 @@ static constexpr dart::compiler::target::word
 static constexpr dart::compiler::target::word
     Thread_no_scope_native_wrapper_entry_point_offset = 0x148;
 static constexpr dart::compiler::target::word
-    Thread_late_initialization_error_shared_with_fpu_regs_stub_offset = 0x68;
+    Thread_late_initialization_error_shared_with_fpu_regs_stub_offset = 0x74;
 static constexpr dart::compiler::target::word
-    Thread_late_initialization_error_shared_without_fpu_regs_stub_offset = 0x64;
+    Thread_late_initialization_error_shared_without_fpu_regs_stub_offset = 0x70;
 static constexpr dart::compiler::target::word
-    Thread_null_error_shared_with_fpu_regs_stub_offset = 0x70;
+    Thread_null_error_shared_with_fpu_regs_stub_offset = 0x7c;
 static constexpr dart::compiler::target::word
-    Thread_null_error_shared_without_fpu_regs_stub_offset = 0x6c;
+    Thread_null_error_shared_without_fpu_regs_stub_offset = 0x78;
 static constexpr dart::compiler::target::word
-    Thread_null_arg_error_shared_with_fpu_regs_stub_offset = 0x78;
+    Thread_null_arg_error_shared_with_fpu_regs_stub_offset = 0x84;
 static constexpr dart::compiler::target::word
-    Thread_null_arg_error_shared_without_fpu_regs_stub_offset = 0x74;
+    Thread_null_arg_error_shared_without_fpu_regs_stub_offset = 0x80;
 static constexpr dart::compiler::target::word
-    Thread_null_cast_error_shared_with_fpu_regs_stub_offset = 0x80;
+    Thread_null_cast_error_shared_with_fpu_regs_stub_offset = 0x8c;
 static constexpr dart::compiler::target::word
-    Thread_null_cast_error_shared_without_fpu_regs_stub_offset = 0x7c;
+    Thread_null_cast_error_shared_without_fpu_regs_stub_offset = 0x88;
 static constexpr dart::compiler::target::word
-    Thread_range_error_shared_with_fpu_regs_stub_offset = 0x88;
+    Thread_range_error_shared_with_fpu_regs_stub_offset = 0x94;
 static constexpr dart::compiler::target::word
-    Thread_range_error_shared_without_fpu_regs_stub_offset = 0x84;
+    Thread_range_error_shared_without_fpu_regs_stub_offset = 0x90;
 static constexpr dart::compiler::target::word
-    Thread_write_error_shared_with_fpu_regs_stub_offset = 0x90;
+    Thread_write_error_shared_with_fpu_regs_stub_offset = 0x9c;
 static constexpr dart::compiler::target::word
-    Thread_write_error_shared_without_fpu_regs_stub_offset = 0x8c;
+    Thread_write_error_shared_without_fpu_regs_stub_offset = 0x98;
 static constexpr dart::compiler::target::word
-    Thread_field_access_error_shared_with_fpu_regs_stub_offset = 0x98;
+    Thread_field_access_error_shared_with_fpu_regs_stub_offset = 0xa4;
 static constexpr dart::compiler::target::word
-    Thread_field_access_error_shared_without_fpu_regs_stub_offset = 0x94;
+    Thread_field_access_error_shared_without_fpu_regs_stub_offset = 0xa0;
 static constexpr dart::compiler::target::word Thread_resume_stub_offset = 0xb4;
 static constexpr dart::compiler::target::word
     Thread_return_async_not_future_stub_offset = 0xbc;
@@ -6535,28 +6563,28 @@ static constexpr dart::compiler::target::word
     Thread_return_async_star_stub_offset = 0xc0;
 static constexpr dart::compiler::target::word Thread_return_async_stub_offset =
     0xb8;
-static constexpr dart::compiler::target::word Thread_object_null_offset = 0x38;
+static constexpr dart::compiler::target::word Thread_object_null_offset = 0x40;
 static constexpr dart::compiler::target::word
     Thread_predefined_symbols_address_offset = 0x154;
 static constexpr dart::compiler::target::word
     Thread_resume_interpreter_adjusted_entry_point_offset = 0x140;
-static constexpr dart::compiler::target::word Thread_resume_pc_offset = 0x3f4;
+static constexpr dart::compiler::target::word Thread_resume_pc_offset = 0x36c;
 static constexpr dart::compiler::target::word
-    Thread_saved_shadow_call_stack_offset = 0x3f8;
+    Thread_saved_shadow_call_stack_offset = 0x370;
 static constexpr dart::compiler::target::word Thread_safepoint_state_offset =
-    0x400;
+    0x378;
 static constexpr dart::compiler::target::word
-    Thread_shared_field_table_values_offset = 0x34;
-static constexpr dart::compiler::target::word Thread_single_step_offset = 0x424;
+    Thread_shared_field_table_values_offset = 0x3c;
+static constexpr dart::compiler::target::word Thread_single_step_offset = 0x46c;
 static constexpr dart::compiler::target::word
     Thread_slow_type_test_stub_offset = 0xe8;
 static constexpr dart::compiler::target::word
     Thread_slow_type_test_entry_point_offset = 0x13c;
-static constexpr dart::compiler::target::word Thread_stack_limit_offset = 0x1c;
+static constexpr dart::compiler::target::word Thread_stack_limit_offset = 0x24;
 static constexpr dart::compiler::target::word Thread_saved_stack_limit_offset =
-    0x3b8;
+    0x340;
 static constexpr dart::compiler::target::word
-    Thread_stack_overflow_flags_offset = 0x3bc;
+    Thread_stack_overflow_flags_offset = 0x344;
 static constexpr dart::compiler::target::word
     Thread_stack_overflow_shared_with_fpu_regs_entry_point_offset = 0x120;
 static constexpr dart::compiler::target::word
@@ -6566,46 +6594,49 @@ static constexpr dart::compiler::target::word
 static constexpr dart::compiler::target::word
     Thread_stack_overflow_shared_without_fpu_regs_stub_offset = 0xc4;
 static constexpr dart::compiler::target::word Thread_store_buffer_block_offset =
-    0x3c4;
+    0x34c;
 static constexpr dart::compiler::target::word
-    Thread_suspend_state_await_entry_point_offset = 0x388;
+    Thread_suspend_state_await_entry_point_offset = 0x310;
 static constexpr dart::compiler::target::word
-    Thread_suspend_state_await_with_type_check_entry_point_offset = 0x38c;
+    Thread_suspend_state_await_with_type_check_entry_point_offset = 0x314;
 static constexpr dart::compiler::target::word
-    Thread_suspend_state_init_async_entry_point_offset = 0x384;
+    Thread_suspend_state_init_async_entry_point_offset = 0x30c;
 static constexpr dart::compiler::target::word
-    Thread_suspend_state_return_async_entry_point_offset = 0x390;
+    Thread_suspend_state_return_async_entry_point_offset = 0x318;
 static constexpr dart::compiler::target::word
-    Thread_suspend_state_return_async_not_future_entry_point_offset = 0x394;
+    Thread_suspend_state_return_async_not_future_entry_point_offset = 0x31c;
 static constexpr dart::compiler::target::word
-    Thread_suspend_state_init_async_star_entry_point_offset = 0x398;
+    Thread_suspend_state_init_async_star_entry_point_offset = 0x320;
 static constexpr dart::compiler::target::word
-    Thread_suspend_state_yield_async_star_entry_point_offset = 0x39c;
+    Thread_suspend_state_yield_async_star_entry_point_offset = 0x324;
 static constexpr dart::compiler::target::word
-    Thread_suspend_state_return_async_star_entry_point_offset = 0x3a0;
+    Thread_suspend_state_return_async_star_entry_point_offset = 0x328;
 static constexpr dart::compiler::target::word
-    Thread_suspend_state_init_sync_star_entry_point_offset = 0x3a4;
+    Thread_suspend_state_init_sync_star_entry_point_offset = 0x32c;
 static constexpr dart::compiler::target::word
-    Thread_suspend_state_suspend_sync_star_at_start_entry_point_offset = 0x3a8;
+    Thread_suspend_state_suspend_sync_star_at_start_entry_point_offset = 0x330;
 static constexpr dart::compiler::target::word
-    Thread_suspend_state_handle_exception_entry_point_offset = 0x3ac;
+    Thread_suspend_state_handle_exception_entry_point_offset = 0x334;
 static constexpr dart::compiler::target::word
-    Thread_top_exit_frame_info_offset = 0x3c0;
-static constexpr dart::compiler::target::word Thread_top_offset = 0x24;
+    Thread_top_exit_frame_info_offset = 0x348;
+static constexpr dart::compiler::target::word Thread_top_offset = 0x2c;
 static constexpr dart::compiler::target::word Thread_top_resource_offset = 0x10;
 static constexpr dart::compiler::target::word
-    Thread_unboxed_runtime_arg_offset = 0x3d8;
-static constexpr dart::compiler::target::word Thread_vm_tag_offset = 0x3d4;
+    Thread_unboxed_runtime_arg_offset = 0x448;
+static constexpr dart::compiler::target::word Thread_vm_tag_offset = 0x35c;
 static constexpr dart::compiler::target::word
     Thread_write_barrier_entry_point_offset = 0xfc;
 static constexpr dart::compiler::target::word Thread_write_barrier_mask_offset =
-    0x20;
+    0x28;
 static constexpr dart::compiler::target::word Thread_next_task_id_offset =
-    0x410;
-static constexpr dart::compiler::target::word Thread_random_offset = 0x418;
+    0x458;
+static constexpr dart::compiler::target::word Thread_random_offset = 0x460;
 static constexpr dart::compiler::target::word
     Thread_jump_to_frame_entry_point_offset = 0x138;
-static constexpr dart::compiler::target::word Thread_tsan_utils_offset = 0x420;
+static constexpr dart::compiler::target::word Thread_tsan_utils_offset = 0x468;
+static constexpr dart::compiler::target::word Thread_current_tag_offset = 0x474;
+static constexpr dart::compiler::target::word Thread_default_tag_offset = 0x478;
+static constexpr dart::compiler::target::word Thread_user_tag_offset = 0x470;
 static constexpr dart::compiler::target::word TsanUtils_setjmp_function_offset =
     0x0;
 static constexpr dart::compiler::target::word TsanUtils_setjmp_buffer_offset =
@@ -6690,9 +6721,9 @@ static constexpr dart::compiler::target::word Code_entry_point_offset[] = {
     0x4, 0xc, 0x8, 0x10};
 static constexpr dart::compiler::target::word
     Thread_write_barrier_wrappers_thread_offset[] = {
-        -1,    -1,    0x338, 0x33c, 0x340, 0x344, 0x348, 0x34c,
-        0x350, 0x354, 0x358, 0x35c, 0x360, 0x364, 0x368, 0x36c,
-        0x370, 0x374, 0x378, -1,    0x37c, 0x380, -1,    -1,
+        -1,    -1,    0x2c0, 0x2c4, 0x2c8, 0x2cc, 0x2d0, 0x2d4,
+        0x2d8, 0x2dc, 0x2e0, 0x2e4, 0x2e8, 0x2ec, 0x2f0, 0x2f4,
+        0x2f8, 0x2fc, 0x300, -1,    0x304, 0x308, -1,    -1,
         -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1};
 static constexpr dart::compiler::target::word AbstractType_InstanceSize = 0x14;
 static constexpr dart::compiler::target::word ApiError_InstanceSize = 0x8;
@@ -6715,7 +6746,7 @@ static constexpr dart::compiler::target::word ExternalTypedData_InstanceSize =
     0xc;
 static constexpr dart::compiler::target::word FfiTrampolineData_InstanceSize =
     0x1c;
-static constexpr dart::compiler::target::word Field_InstanceSize = 0x3c;
+static constexpr dart::compiler::target::word Field_InstanceSize = 0x44;
 static constexpr dart::compiler::target::word Finalizer_InstanceSize = 0x1c;
 static constexpr dart::compiler::target::word FinalizerEntry_InstanceSize =
     0x20;
@@ -6789,7 +6820,7 @@ static constexpr dart::compiler::target::word UnhandledException_InstanceSize =
     0xc;
 static constexpr dart::compiler::target::word UnlinkedCall_InstanceSize = 0x10;
 static constexpr dart::compiler::target::word UnwindError_InstanceSize = 0xc;
-static constexpr dart::compiler::target::word UserTag_InstanceSize = 0x10;
+static constexpr dart::compiler::target::word UserTag_InstanceSize = 0xc;
 static constexpr dart::compiler::target::word WeakProperty_InstanceSize = 0x10;
 static constexpr dart::compiler::target::word WeakReference_InstanceSize = 0x10;
 static constexpr dart::compiler::target::word
@@ -12842,6 +12873,8 @@ static constexpr dart::compiler::target::word Array_kMaxElements = 0xfffffff;
 static constexpr dart::compiler::target::word Array_kMaxNewSpaceElements =
     0xfffd;
 static constexpr dart::compiler::target::word Context_kMaxElements = 0xfffffff;
+static constexpr dart::compiler::target::word Heap_kNewAllocatableSize =
+    0x40000;
 static constexpr dart::compiler::target::word
     Instructions_kMonomorphicEntryOffsetJIT = 0xc;
 static constexpr dart::compiler::target::word
@@ -12857,6 +12890,7 @@ static constexpr dart::compiler::target::word
 static constexpr dart::compiler::target::word
     NativeEntry_kNumCallWrapperArguments = 0x2;
 static constexpr dart::compiler::target::word Page_kBytesPerCardLog2 = 0x7;
+static constexpr dart::compiler::target::word Page_kPageMask = -0x80000;
 static constexpr dart::compiler::target::word Record_kMaxElements = 0xffff;
 static constexpr dart::compiler::target::word RecordShape_kFieldNamesIndexMask =
     0x3fff;
@@ -12894,6 +12928,34 @@ static constexpr dart::compiler::target::word SubtypeTestCache_kTestResult =
     0x7;
 static constexpr dart::compiler::target::word TypeArguments_kMaxElements =
     0xfffffff;
+static constexpr dart::compiler::target::word
+    UntaggedObject_kCardRememberedBit = 0x0;
+static constexpr dart::compiler::target::word UntaggedObject_kCanonicalBit =
+    0x1;
+static constexpr dart::compiler::target::word UntaggedObject_kNotMarkedBit =
+    0x2;
+static constexpr dart::compiler::target::word
+    UntaggedObject_kNewOrEvacuationCandidateBit = 0x3;
+static constexpr dart::compiler::target::word UntaggedObject_kAlwaysSetBit =
+    0x4;
+static constexpr dart::compiler::target::word
+    UntaggedObject_kOldAndNotRememberedBit = 0x5;
+static constexpr dart::compiler::target::word
+    UntaggedObject_kIncrementalBarrierMask = 0x4;
+static constexpr dart::compiler::target::word
+    UntaggedObject_kGenerationalBarrierMask = 0x8;
+static constexpr dart::compiler::target::word
+    UntaggedObject_kBarrierOverlapShift = 0x2;
+static constexpr dart::compiler::target::word
+    UntaggedObject_kShallowImmutableBit = 0x6;
+static constexpr dart::compiler::target::word
+    UntaggedObject_kDeeplyImmutableBit = 0x7;
+static constexpr dart::compiler::target::word UntaggedObject_kSizeTagPos = 0x8;
+static constexpr dart::compiler::target::word UntaggedObject_kSizeTagSize = 0x4;
+static constexpr dart::compiler::target::word UntaggedObject_kClassIdTagPos =
+    0xc;
+static constexpr dart::compiler::target::word UntaggedObject_kClassIdTagSize =
+    0x14;
 static constexpr dart::compiler::target::word AbstractType_flags_offset = 0x8;
 static constexpr dart::compiler::target::word AbstractType_hash_offset = 0x10;
 static constexpr dart::compiler::target::word
@@ -12949,13 +13011,13 @@ static constexpr dart::compiler::target::word
     Field_initializer_function_offset = 0x10;
 static constexpr dart::compiler::target::word
     Field_host_offset_or_field_id_offset = 0x14;
-static constexpr dart::compiler::target::word Field_guarded_cid_offset = 0x28;
+static constexpr dart::compiler::target::word Field_guarded_cid_offset = 0x2c;
 static constexpr dart::compiler::target::word
-    Field_guarded_list_length_in_object_offset_offset = 0x34;
+    Field_guarded_list_length_in_object_offset_offset = 0x38;
 static constexpr dart::compiler::target::word Field_guarded_list_length_offset =
     0x18;
-static constexpr dart::compiler::target::word Field_is_nullable_offset = 0x2c;
-static constexpr dart::compiler::target::word Field_kind_bits_offset = 0x36;
+static constexpr dart::compiler::target::word Field_is_nullable_offset = 0x30;
+static constexpr dart::compiler::target::word Field_kind_bits_offset = 0x3c;
 static constexpr dart::compiler::target::word Function_code_offset = 0x20;
 static constexpr dart::compiler::target::word Function_data_offset = 0x18;
 static constexpr dart::compiler::target::word Function_entry_point_offset[] = {
@@ -12980,17 +13042,15 @@ static constexpr dart::compiler::target::word ICData_NumArgsTestedShift = 0x0;
 static constexpr dart::compiler::target::word ICData_entries_offset = 0xc;
 static constexpr dart::compiler::target::word ICData_owner_offset = 0x14;
 static constexpr dart::compiler::target::word ICData_state_bits_offset = 0x1c;
+static constexpr dart::compiler::target::word Instance_first_field_offset = 0x4;
 static constexpr dart::compiler::target::word Int32x4_value_offset = 0x8;
-static constexpr dart::compiler::target::word Isolate_current_tag_offset = 0xc;
-static constexpr dart::compiler::target::word Isolate_default_tag_offset = 0x10;
-static constexpr dart::compiler::target::word Isolate_finalizers_offset = 0x18;
+static constexpr dart::compiler::target::word Isolate_finalizers_offset = 0xc;
 static constexpr dart::compiler::target::word IsolateGroup_object_store_offset =
     0x10;
 static constexpr dart::compiler::target::word IsolateGroup_class_table_offset =
     0x8;
 static constexpr dart::compiler::target::word
     IsolateGroup_cached_class_table_table_offset = 0xc;
-static constexpr dart::compiler::target::word Isolate_user_tag_offset = 0x8;
 static constexpr dart::compiler::target::word LinkedHashBase_data_offset = 0xc;
 static constexpr dart::compiler::target::word
     ImmutableLinkedHashBase_data_offset = 0xc;
@@ -13021,40 +13081,41 @@ static constexpr dart::compiler::target::word NativeArguments_retval_offset =
     0xc;
 static constexpr dart::compiler::target::word NativeArguments_thread_offset =
     0x0;
+static constexpr dart::compiler::target::word Object_tags_offset = 0x0;
 static constexpr dart::compiler::target::word ObjectStore_double_type_offset =
-    0xc0;
+    0xdc;
 static constexpr dart::compiler::target::word ObjectStore_int_type_offset =
-    0x98;
+    0xb4;
 static constexpr dart::compiler::target::word
-    ObjectStore_record_field_names_offset = 0x1f8;
+    ObjectStore_record_field_names_offset = 0x218;
 static constexpr dart::compiler::target::word ObjectStore_string_type_offset =
-    0xd4;
+    0xf0;
 static constexpr dart::compiler::target::word ObjectStore_type_type_offset =
-    0x84;
+    0xa0;
 static constexpr dart::compiler::target::word
-    ObjectStore_ffi_callback_code_offset = 0x274;
+    ObjectStore_ffi_callback_code_offset = 0x294;
 static constexpr dart::compiler::target::word
-    ObjectStore_suspend_state_await_offset = 0x220;
+    ObjectStore_suspend_state_await_offset = 0x240;
 static constexpr dart::compiler::target::word
-    ObjectStore_suspend_state_await_with_type_check_offset = 0x224;
+    ObjectStore_suspend_state_await_with_type_check_offset = 0x244;
 static constexpr dart::compiler::target::word
-    ObjectStore_suspend_state_handle_exception_offset = 0x244;
+    ObjectStore_suspend_state_handle_exception_offset = 0x264;
 static constexpr dart::compiler::target::word
-    ObjectStore_suspend_state_init_async_offset = 0x21c;
+    ObjectStore_suspend_state_init_async_offset = 0x23c;
 static constexpr dart::compiler::target::word
-    ObjectStore_suspend_state_init_async_star_offset = 0x230;
+    ObjectStore_suspend_state_init_async_star_offset = 0x250;
 static constexpr dart::compiler::target::word
-    ObjectStore_suspend_state_init_sync_star_offset = 0x23c;
+    ObjectStore_suspend_state_init_sync_star_offset = 0x25c;
 static constexpr dart::compiler::target::word
-    ObjectStore_suspend_state_return_async_offset = 0x228;
+    ObjectStore_suspend_state_return_async_offset = 0x248;
 static constexpr dart::compiler::target::word
-    ObjectStore_suspend_state_return_async_not_future_offset = 0x22c;
+    ObjectStore_suspend_state_return_async_not_future_offset = 0x24c;
 static constexpr dart::compiler::target::word
-    ObjectStore_suspend_state_return_async_star_offset = 0x238;
+    ObjectStore_suspend_state_return_async_star_offset = 0x258;
 static constexpr dart::compiler::target::word
-    ObjectStore_suspend_state_suspend_sync_star_at_start_offset = 0x240;
+    ObjectStore_suspend_state_suspend_sync_star_at_start_offset = 0x260;
 static constexpr dart::compiler::target::word
-    ObjectStore_suspend_state_yield_async_star_offset = 0x234;
+    ObjectStore_suspend_state_yield_async_star_offset = 0x254;
 static constexpr dart::compiler::target::word OneByteString_data_offset = 0xc;
 static constexpr dart::compiler::target::word PersistentHandle_ptr_offset = 0x0;
 static constexpr dart::compiler::target::word PointerBase_data_offset = 0x4;
@@ -13097,53 +13158,51 @@ static constexpr dart::compiler::target::word
     SuspendState_then_callback_offset = 0x14;
 static constexpr dart::compiler::target::word
     Thread_AllocateArray_entry_point_offset = 0x174;
+static constexpr dart::compiler::target::word
+    Thread_DeoptimizeCopyFrame_entry_point_offset = 0x380;
 static constexpr dart::compiler::target::word Thread_active_exception_offset =
-    0x3e8;
+    0x360;
 static constexpr dart::compiler::target::word Thread_active_stacktrace_offset =
-    0x3ec;
+    0x364;
 static constexpr dart::compiler::target::word
     Thread_array_write_barrier_entry_point_offset = 0x100;
 static constexpr dart::compiler::target::word
     Thread_allocate_mint_with_fpu_regs_entry_point_offset = 0x108;
 static constexpr dart::compiler::target::word
-    Thread_allocate_mint_with_fpu_regs_stub_offset = 0x9c;
+    Thread_allocate_mint_with_fpu_regs_stub_offset = 0xa8;
 static constexpr dart::compiler::target::word
     Thread_allocate_mint_without_fpu_regs_entry_point_offset = 0x10c;
 static constexpr dart::compiler::target::word
-    Thread_allocate_mint_without_fpu_regs_stub_offset = 0xa0;
+    Thread_allocate_mint_without_fpu_regs_stub_offset = 0xac;
 static constexpr dart::compiler::target::word
     Thread_allocate_object_entry_point_offset = 0x110;
 static constexpr dart::compiler::target::word
-    Thread_allocate_object_stub_offset = 0xa4;
-static constexpr dart::compiler::target::word
     Thread_allocate_object_parameterized_entry_point_offset = 0x114;
 static constexpr dart::compiler::target::word
-    Thread_allocate_object_parameterized_stub_offset = 0xa8;
-static constexpr dart::compiler::target::word
     Thread_allocate_object_slow_entry_point_offset = 0x118;
-static constexpr dart::compiler::target::word
-    Thread_allocate_object_slow_stub_offset = 0xac;
 static constexpr dart::compiler::target::word Thread_api_top_scope_offset =
-    0x408;
+    0x440;
 static constexpr dart::compiler::target::word
     Thread_async_exception_handler_stub_offset = 0xb0;
 static constexpr dart::compiler::target::word
     Thread_auto_scope_native_wrapper_entry_point_offset = 0x14c;
-static constexpr dart::compiler::target::word Thread_bool_false_offset = 0x40;
-static constexpr dart::compiler::target::word Thread_bool_true_offset = 0x3c;
+static constexpr dart::compiler::target::word Thread_bool_false_offset = 0x4c;
+static constexpr dart::compiler::target::word Thread_bool_true_offset = 0x48;
 static constexpr dart::compiler::target::word
     Thread_bootstrap_native_wrapper_entry_point_offset = 0x144;
 static constexpr dart::compiler::target::word
     Thread_call_to_runtime_entry_point_offset = 0x104;
 static constexpr dart::compiler::target::word
-    Thread_call_to_runtime_stub_offset = 0x60;
-static constexpr dart::compiler::target::word Thread_dart_stream_offset = 0x430;
+    Thread_call_to_runtime_stub_offset = 0x6c;
+static constexpr dart::compiler::target::word Thread_dart_stream_offset = 0x47c;
 static constexpr dart::compiler::target::word
-    Thread_dispatch_table_array_offset = 0x2c;
+    Thread_dispatch_table_array_offset = 0x34;
 static constexpr dart::compiler::target::word
-    Thread_double_truncate_round_supported_offset = 0x40c;
+    Thread_double_truncate_round_supported_offset = 0x444;
 static constexpr dart::compiler::target::word
-    Thread_service_extension_stream_offset = 0x434;
+    Thread_service_extension_stream_offset = 0x480;
+static constexpr dart::compiler::target::word Thread_thread_locals_offset =
+    0x484;
 static constexpr dart::compiler::target::word Thread_optimize_entry_offset =
     0x12c;
 static constexpr dart::compiler::target::word Thread_optimize_stub_offset =
@@ -13156,11 +13215,11 @@ static constexpr dart::compiler::target::word Thread_double_abs_address_offset =
     0x160;
 static constexpr dart::compiler::target::word
     Thread_double_negate_address_offset = 0x15c;
-static constexpr dart::compiler::target::word Thread_end_offset = 0x28;
+static constexpr dart::compiler::target::word Thread_end_offset = 0x30;
 static constexpr dart::compiler::target::word
     Thread_enter_safepoint_stub_offset = 0xf0;
 static constexpr dart::compiler::target::word Thread_execution_state_offset =
-    0x3fc;
+    0x374;
 static constexpr dart::compiler::target::word
     Thread_exit_safepoint_stub_offset = 0xf4;
 static constexpr dart::compiler::target::word
@@ -13168,9 +13227,9 @@ static constexpr dart::compiler::target::word
 static constexpr dart::compiler::target::word
     Thread_call_native_through_safepoint_entry_point_offset = 0x134;
 static constexpr dart::compiler::target::word
-    Thread_fix_allocation_stub_code_offset = 0x54;
+    Thread_fix_allocation_stub_code_offset = 0x60;
 static constexpr dart::compiler::target::word
-    Thread_fix_callers_target_code_offset = 0x50;
+    Thread_fix_callers_target_code_offset = 0x5c;
 static constexpr dart::compiler::target::word
     Thread_float_absolute_address_offset = 0x16c;
 static constexpr dart::compiler::target::word
@@ -13180,20 +13239,20 @@ static constexpr dart::compiler::target::word Thread_float_not_address_offset =
 static constexpr dart::compiler::target::word
     Thread_float_zerow_address_offset = 0x170;
 static constexpr dart::compiler::target::word Thread_global_object_pool_offset =
-    0x3f0;
+    0x368;
 static constexpr dart::compiler::target::word
     Thread_interpret_call_entry_point_offset = 0x150;
 static constexpr dart::compiler::target::word
-    Thread_invoke_dart_code_from_bytecode_stub_offset = 0x5c;
+    Thread_invoke_dart_code_from_bytecode_stub_offset = 0x68;
 static constexpr dart::compiler::target::word
-    Thread_invoke_dart_code_stub_offset = 0x58;
+    Thread_invoke_dart_code_stub_offset = 0x64;
 static constexpr dart::compiler::target::word Thread_exit_through_ffi_offset =
-    0x404;
-static constexpr dart::compiler::target::word Thread_isolate_offset = 0x3b0;
+    0x37c;
+static constexpr dart::compiler::target::word Thread_isolate_offset = 0x338;
 static constexpr dart::compiler::target::word Thread_isolate_group_offset =
-    0x3b4;
+    0x33c;
 static constexpr dart::compiler::target::word Thread_field_table_values_offset =
-    0x30;
+    0x38;
 static constexpr dart::compiler::target::word
     Thread_lazy_deopt_from_return_stub_offset = 0xe0;
 static constexpr dart::compiler::target::word
@@ -13201,9 +13260,9 @@ static constexpr dart::compiler::target::word
 static constexpr dart::compiler::target::word
     Thread_lazy_specialize_type_test_stub_offset = 0xec;
 static constexpr dart::compiler::target::word
-    Thread_old_marking_stack_block_offset = 0x3c8;
+    Thread_old_marking_stack_block_offset = 0x350;
 static constexpr dart::compiler::target::word
-    Thread_new_marking_stack_block_offset = 0x3cc;
+    Thread_new_marking_stack_block_offset = 0x354;
 static constexpr dart::compiler::target::word
     Thread_megamorphic_call_checked_entry_offset = 0x124;
 static constexpr dart::compiler::target::word
@@ -13213,33 +13272,33 @@ static constexpr dart::compiler::target::word
 static constexpr dart::compiler::target::word
     Thread_no_scope_native_wrapper_entry_point_offset = 0x148;
 static constexpr dart::compiler::target::word
-    Thread_late_initialization_error_shared_with_fpu_regs_stub_offset = 0x68;
+    Thread_late_initialization_error_shared_with_fpu_regs_stub_offset = 0x74;
 static constexpr dart::compiler::target::word
-    Thread_late_initialization_error_shared_without_fpu_regs_stub_offset = 0x64;
+    Thread_late_initialization_error_shared_without_fpu_regs_stub_offset = 0x70;
 static constexpr dart::compiler::target::word
-    Thread_null_error_shared_with_fpu_regs_stub_offset = 0x70;
+    Thread_null_error_shared_with_fpu_regs_stub_offset = 0x7c;
 static constexpr dart::compiler::target::word
-    Thread_null_error_shared_without_fpu_regs_stub_offset = 0x6c;
+    Thread_null_error_shared_without_fpu_regs_stub_offset = 0x78;
 static constexpr dart::compiler::target::word
-    Thread_null_arg_error_shared_with_fpu_regs_stub_offset = 0x78;
+    Thread_null_arg_error_shared_with_fpu_regs_stub_offset = 0x84;
 static constexpr dart::compiler::target::word
-    Thread_null_arg_error_shared_without_fpu_regs_stub_offset = 0x74;
+    Thread_null_arg_error_shared_without_fpu_regs_stub_offset = 0x80;
 static constexpr dart::compiler::target::word
-    Thread_null_cast_error_shared_with_fpu_regs_stub_offset = 0x80;
+    Thread_null_cast_error_shared_with_fpu_regs_stub_offset = 0x8c;
 static constexpr dart::compiler::target::word
-    Thread_null_cast_error_shared_without_fpu_regs_stub_offset = 0x7c;
+    Thread_null_cast_error_shared_without_fpu_regs_stub_offset = 0x88;
 static constexpr dart::compiler::target::word
-    Thread_range_error_shared_with_fpu_regs_stub_offset = 0x88;
+    Thread_range_error_shared_with_fpu_regs_stub_offset = 0x94;
 static constexpr dart::compiler::target::word
-    Thread_range_error_shared_without_fpu_regs_stub_offset = 0x84;
+    Thread_range_error_shared_without_fpu_regs_stub_offset = 0x90;
 static constexpr dart::compiler::target::word
-    Thread_write_error_shared_with_fpu_regs_stub_offset = 0x90;
+    Thread_write_error_shared_with_fpu_regs_stub_offset = 0x9c;
 static constexpr dart::compiler::target::word
-    Thread_write_error_shared_without_fpu_regs_stub_offset = 0x8c;
+    Thread_write_error_shared_without_fpu_regs_stub_offset = 0x98;
 static constexpr dart::compiler::target::word
-    Thread_field_access_error_shared_with_fpu_regs_stub_offset = 0x98;
+    Thread_field_access_error_shared_with_fpu_regs_stub_offset = 0xa4;
 static constexpr dart::compiler::target::word
-    Thread_field_access_error_shared_without_fpu_regs_stub_offset = 0x94;
+    Thread_field_access_error_shared_without_fpu_regs_stub_offset = 0xa0;
 static constexpr dart::compiler::target::word Thread_resume_stub_offset = 0xb4;
 static constexpr dart::compiler::target::word
     Thread_return_async_not_future_stub_offset = 0xbc;
@@ -13247,27 +13306,27 @@ static constexpr dart::compiler::target::word
     Thread_return_async_star_stub_offset = 0xc0;
 static constexpr dart::compiler::target::word Thread_return_async_stub_offset =
     0xb8;
-static constexpr dart::compiler::target::word Thread_object_null_offset = 0x38;
+static constexpr dart::compiler::target::word Thread_object_null_offset = 0x40;
 static constexpr dart::compiler::target::word
     Thread_predefined_symbols_address_offset = 0x154;
 static constexpr dart::compiler::target::word
     Thread_resume_interpreter_adjusted_entry_point_offset = 0x140;
-static constexpr dart::compiler::target::word Thread_resume_pc_offset = 0x3f4;
+static constexpr dart::compiler::target::word Thread_resume_pc_offset = 0x36c;
 static constexpr dart::compiler::target::word
-    Thread_saved_shadow_call_stack_offset = 0x3f8;
+    Thread_saved_shadow_call_stack_offset = 0x370;
 static constexpr dart::compiler::target::word Thread_safepoint_state_offset =
-    0x400;
+    0x378;
 static constexpr dart::compiler::target::word
-    Thread_shared_field_table_values_offset = 0x34;
+    Thread_shared_field_table_values_offset = 0x3c;
 static constexpr dart::compiler::target::word
     Thread_slow_type_test_stub_offset = 0xe8;
 static constexpr dart::compiler::target::word
     Thread_slow_type_test_entry_point_offset = 0x13c;
-static constexpr dart::compiler::target::word Thread_stack_limit_offset = 0x1c;
+static constexpr dart::compiler::target::word Thread_stack_limit_offset = 0x24;
 static constexpr dart::compiler::target::word Thread_saved_stack_limit_offset =
-    0x3b8;
+    0x340;
 static constexpr dart::compiler::target::word
-    Thread_stack_overflow_flags_offset = 0x3bc;
+    Thread_stack_overflow_flags_offset = 0x344;
 static constexpr dart::compiler::target::word
     Thread_stack_overflow_shared_with_fpu_regs_entry_point_offset = 0x120;
 static constexpr dart::compiler::target::word
@@ -13277,46 +13336,49 @@ static constexpr dart::compiler::target::word
 static constexpr dart::compiler::target::word
     Thread_stack_overflow_shared_without_fpu_regs_stub_offset = 0xc4;
 static constexpr dart::compiler::target::word Thread_store_buffer_block_offset =
-    0x3c4;
+    0x34c;
 static constexpr dart::compiler::target::word
-    Thread_suspend_state_await_entry_point_offset = 0x388;
+    Thread_suspend_state_await_entry_point_offset = 0x310;
 static constexpr dart::compiler::target::word
-    Thread_suspend_state_await_with_type_check_entry_point_offset = 0x38c;
+    Thread_suspend_state_await_with_type_check_entry_point_offset = 0x314;
 static constexpr dart::compiler::target::word
-    Thread_suspend_state_init_async_entry_point_offset = 0x384;
+    Thread_suspend_state_init_async_entry_point_offset = 0x30c;
 static constexpr dart::compiler::target::word
-    Thread_suspend_state_return_async_entry_point_offset = 0x390;
+    Thread_suspend_state_return_async_entry_point_offset = 0x318;
 static constexpr dart::compiler::target::word
-    Thread_suspend_state_return_async_not_future_entry_point_offset = 0x394;
+    Thread_suspend_state_return_async_not_future_entry_point_offset = 0x31c;
 static constexpr dart::compiler::target::word
-    Thread_suspend_state_init_async_star_entry_point_offset = 0x398;
+    Thread_suspend_state_init_async_star_entry_point_offset = 0x320;
 static constexpr dart::compiler::target::word
-    Thread_suspend_state_yield_async_star_entry_point_offset = 0x39c;
+    Thread_suspend_state_yield_async_star_entry_point_offset = 0x324;
 static constexpr dart::compiler::target::word
-    Thread_suspend_state_return_async_star_entry_point_offset = 0x3a0;
+    Thread_suspend_state_return_async_star_entry_point_offset = 0x328;
 static constexpr dart::compiler::target::word
-    Thread_suspend_state_init_sync_star_entry_point_offset = 0x3a4;
+    Thread_suspend_state_init_sync_star_entry_point_offset = 0x32c;
 static constexpr dart::compiler::target::word
-    Thread_suspend_state_suspend_sync_star_at_start_entry_point_offset = 0x3a8;
+    Thread_suspend_state_suspend_sync_star_at_start_entry_point_offset = 0x330;
 static constexpr dart::compiler::target::word
-    Thread_suspend_state_handle_exception_entry_point_offset = 0x3ac;
+    Thread_suspend_state_handle_exception_entry_point_offset = 0x334;
 static constexpr dart::compiler::target::word
-    Thread_top_exit_frame_info_offset = 0x3c0;
-static constexpr dart::compiler::target::word Thread_top_offset = 0x24;
+    Thread_top_exit_frame_info_offset = 0x348;
+static constexpr dart::compiler::target::word Thread_top_offset = 0x2c;
 static constexpr dart::compiler::target::word Thread_top_resource_offset = 0x10;
 static constexpr dart::compiler::target::word
-    Thread_unboxed_runtime_arg_offset = 0x3d8;
-static constexpr dart::compiler::target::word Thread_vm_tag_offset = 0x3d4;
+    Thread_unboxed_runtime_arg_offset = 0x448;
+static constexpr dart::compiler::target::word Thread_vm_tag_offset = 0x35c;
 static constexpr dart::compiler::target::word
     Thread_write_barrier_entry_point_offset = 0xfc;
 static constexpr dart::compiler::target::word Thread_write_barrier_mask_offset =
-    0x20;
+    0x28;
 static constexpr dart::compiler::target::word Thread_next_task_id_offset =
-    0x410;
-static constexpr dart::compiler::target::word Thread_random_offset = 0x418;
+    0x458;
+static constexpr dart::compiler::target::word Thread_random_offset = 0x460;
 static constexpr dart::compiler::target::word
     Thread_jump_to_frame_entry_point_offset = 0x138;
-static constexpr dart::compiler::target::word Thread_tsan_utils_offset = 0x420;
+static constexpr dart::compiler::target::word Thread_tsan_utils_offset = 0x468;
+static constexpr dart::compiler::target::word Thread_current_tag_offset = 0x474;
+static constexpr dart::compiler::target::word Thread_default_tag_offset = 0x478;
+static constexpr dart::compiler::target::word Thread_user_tag_offset = 0x470;
 static constexpr dart::compiler::target::word TsanUtils_setjmp_function_offset =
     0x0;
 static constexpr dart::compiler::target::word TsanUtils_setjmp_buffer_offset =
@@ -13401,9 +13463,9 @@ static constexpr dart::compiler::target::word Code_entry_point_offset[] = {
     0x4, 0xc, 0x8, 0x10};
 static constexpr dart::compiler::target::word
     Thread_write_barrier_wrappers_thread_offset[] = {
-        -1,    -1,    0x338, 0x33c, 0x340, 0x344, 0x348, 0x34c,
-        0x350, 0x354, 0x358, 0x35c, 0x360, 0x364, 0x368, 0x36c,
-        0x370, 0x374, 0x378, -1,    0x37c, 0x380, -1,    -1,
+        -1,    -1,    0x2c0, 0x2c4, 0x2c8, 0x2cc, 0x2d0, 0x2d4,
+        0x2d8, 0x2dc, 0x2e0, 0x2e4, 0x2e8, 0x2ec, 0x2f0, 0x2f4,
+        0x2f8, 0x2fc, 0x300, -1,    0x304, 0x308, -1,    -1,
         -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1};
 static constexpr dart::compiler::target::word AbstractType_InstanceSize = 0x14;
 static constexpr dart::compiler::target::word ApiError_InstanceSize = 0x8;
@@ -13426,7 +13488,7 @@ static constexpr dart::compiler::target::word ExternalTypedData_InstanceSize =
     0xc;
 static constexpr dart::compiler::target::word FfiTrampolineData_InstanceSize =
     0x1c;
-static constexpr dart::compiler::target::word Field_InstanceSize = 0x3c;
+static constexpr dart::compiler::target::word Field_InstanceSize = 0x44;
 static constexpr dart::compiler::target::word Finalizer_InstanceSize = 0x1c;
 static constexpr dart::compiler::target::word FinalizerEntry_InstanceSize =
     0x20;
@@ -13500,7 +13562,7 @@ static constexpr dart::compiler::target::word UnhandledException_InstanceSize =
     0xc;
 static constexpr dart::compiler::target::word UnlinkedCall_InstanceSize = 0x10;
 static constexpr dart::compiler::target::word UnwindError_InstanceSize = 0xc;
-static constexpr dart::compiler::target::word UserTag_InstanceSize = 0x10;
+static constexpr dart::compiler::target::word UserTag_InstanceSize = 0xc;
 static constexpr dart::compiler::target::word WeakProperty_InstanceSize = 0x10;
 static constexpr dart::compiler::target::word WeakReference_InstanceSize = 0x10;
 static constexpr dart::compiler::target::word
@@ -19453,6 +19515,8 @@ static constexpr dart::compiler::target::word AOT_Array_kMaxNewSpaceElements =
     0xfffd;
 static constexpr dart::compiler::target::word AOT_Context_kMaxElements =
     0xfffffff;
+static constexpr dart::compiler::target::word AOT_Heap_kNewAllocatableSize =
+    0x40000;
 static constexpr dart::compiler::target::word
     AOT_Instructions_kMonomorphicEntryOffsetJIT = 0xc;
 static constexpr dart::compiler::target::word
@@ -19468,6 +19532,7 @@ static constexpr dart::compiler::target::word
 static constexpr dart::compiler::target::word
     AOT_NativeEntry_kNumCallWrapperArguments = 0x2;
 static constexpr dart::compiler::target::word AOT_Page_kBytesPerCardLog2 = 0x7;
+static constexpr dart::compiler::target::word AOT_Page_kPageMask = -0x80000;
 static constexpr dart::compiler::target::word AOT_Record_kMaxElements = 0xffff;
 static constexpr dart::compiler::target::word
     AOT_RecordShape_kFieldNamesIndexMask = 0x3fff;
@@ -19507,6 +19572,36 @@ static constexpr dart::compiler::target::word AOT_SubtypeTestCache_kTestResult =
     0x7;
 static constexpr dart::compiler::target::word AOT_TypeArguments_kMaxElements =
     0xfffffff;
+static constexpr dart::compiler::target::word
+    AOT_UntaggedObject_kCardRememberedBit = 0x0;
+static constexpr dart::compiler::target::word AOT_UntaggedObject_kCanonicalBit =
+    0x1;
+static constexpr dart::compiler::target::word AOT_UntaggedObject_kNotMarkedBit =
+    0x2;
+static constexpr dart::compiler::target::word
+    AOT_UntaggedObject_kNewOrEvacuationCandidateBit = 0x3;
+static constexpr dart::compiler::target::word AOT_UntaggedObject_kAlwaysSetBit =
+    0x4;
+static constexpr dart::compiler::target::word
+    AOT_UntaggedObject_kOldAndNotRememberedBit = 0x5;
+static constexpr dart::compiler::target::word
+    AOT_UntaggedObject_kIncrementalBarrierMask = 0x4;
+static constexpr dart::compiler::target::word
+    AOT_UntaggedObject_kGenerationalBarrierMask = 0x8;
+static constexpr dart::compiler::target::word
+    AOT_UntaggedObject_kBarrierOverlapShift = 0x2;
+static constexpr dart::compiler::target::word
+    AOT_UntaggedObject_kShallowImmutableBit = 0x6;
+static constexpr dart::compiler::target::word
+    AOT_UntaggedObject_kDeeplyImmutableBit = 0x7;
+static constexpr dart::compiler::target::word AOT_UntaggedObject_kSizeTagPos =
+    0x8;
+static constexpr dart::compiler::target::word AOT_UntaggedObject_kSizeTagSize =
+    0x4;
+static constexpr dart::compiler::target::word
+    AOT_UntaggedObject_kClassIdTagPos = 0xc;
+static constexpr dart::compiler::target::word
+    AOT_UntaggedObject_kClassIdTagSize = 0x14;
 static constexpr dart::compiler::target::word AOT_AbstractType_flags_offset =
     0x8;
 static constexpr dart::compiler::target::word AOT_AbstractType_hash_offset =
@@ -19579,7 +19674,7 @@ static constexpr dart::compiler::target::word
     AOT_Field_guarded_list_length_offset = 0x18;
 static constexpr dart::compiler::target::word AOT_Field_is_nullable_offset =
     0x2c;
-static constexpr dart::compiler::target::word AOT_Field_kind_bits_offset = 0x32;
+static constexpr dart::compiler::target::word AOT_Field_kind_bits_offset = 0x34;
 static constexpr dart::compiler::target::word AOT_Function_code_offset = 0x20;
 static constexpr dart::compiler::target::word AOT_Function_data_offset = 0x18;
 static constexpr dart::compiler::target::word
@@ -19611,22 +19706,19 @@ static constexpr dart::compiler::target::word AOT_ICData_entries_offset = 0xc;
 static constexpr dart::compiler::target::word AOT_ICData_owner_offset = 0x10;
 static constexpr dart::compiler::target::word AOT_ICData_state_bits_offset =
     0x14;
+static constexpr dart::compiler::target::word AOT_Instance_first_field_offset =
+    0x4;
 static constexpr dart::compiler::target::word AOT_Int32x4_value_offset = 0x8;
-static constexpr dart::compiler::target::word AOT_Isolate_current_tag_offset =
-    0xc;
-static constexpr dart::compiler::target::word AOT_Isolate_default_tag_offset =
-    0x10;
 static constexpr dart::compiler::target::word AOT_Isolate_finalizers_offset =
-    0x18;
+    0xc;
 static constexpr dart::compiler::target::word
-    AOT_Isolate_has_resumption_breakpoints_offset = 0x1c;
+    AOT_Isolate_has_resumption_breakpoints_offset = 0x10;
 static constexpr dart::compiler::target::word
     AOT_IsolateGroup_object_store_offset = 0x10;
 static constexpr dart::compiler::target::word
     AOT_IsolateGroup_class_table_offset = 0x8;
 static constexpr dart::compiler::target::word
     AOT_IsolateGroup_cached_class_table_table_offset = 0xc;
-static constexpr dart::compiler::target::word AOT_Isolate_user_tag_offset = 0x8;
 static constexpr dart::compiler::target::word AOT_LinkedHashBase_data_offset =
     0xc;
 static constexpr dart::compiler::target::word
@@ -19659,40 +19751,41 @@ static constexpr dart::compiler::target::word
     AOT_NativeArguments_retval_offset = 0xc;
 static constexpr dart::compiler::target::word
     AOT_NativeArguments_thread_offset = 0x0;
+static constexpr dart::compiler::target::word AOT_Object_tags_offset = 0x0;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_double_type_offset = 0xc0;
+    AOT_ObjectStore_double_type_offset = 0xdc;
 static constexpr dart::compiler::target::word AOT_ObjectStore_int_type_offset =
-    0x98;
+    0xb4;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_record_field_names_offset = 0x1f8;
+    AOT_ObjectStore_record_field_names_offset = 0x218;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_string_type_offset = 0xd4;
+    AOT_ObjectStore_string_type_offset = 0xf0;
 static constexpr dart::compiler::target::word AOT_ObjectStore_type_type_offset =
-    0x84;
+    0xa0;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_ffi_callback_code_offset = 0x274;
+    AOT_ObjectStore_ffi_callback_code_offset = 0x294;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_suspend_state_await_offset = 0x220;
+    AOT_ObjectStore_suspend_state_await_offset = 0x240;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_suspend_state_await_with_type_check_offset = 0x224;
+    AOT_ObjectStore_suspend_state_await_with_type_check_offset = 0x244;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_suspend_state_handle_exception_offset = 0x244;
+    AOT_ObjectStore_suspend_state_handle_exception_offset = 0x264;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_suspend_state_init_async_offset = 0x21c;
+    AOT_ObjectStore_suspend_state_init_async_offset = 0x23c;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_suspend_state_init_async_star_offset = 0x230;
+    AOT_ObjectStore_suspend_state_init_async_star_offset = 0x250;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_suspend_state_init_sync_star_offset = 0x23c;
+    AOT_ObjectStore_suspend_state_init_sync_star_offset = 0x25c;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_suspend_state_return_async_offset = 0x228;
+    AOT_ObjectStore_suspend_state_return_async_offset = 0x248;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_suspend_state_return_async_not_future_offset = 0x22c;
+    AOT_ObjectStore_suspend_state_return_async_not_future_offset = 0x24c;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_suspend_state_return_async_star_offset = 0x238;
+    AOT_ObjectStore_suspend_state_return_async_star_offset = 0x258;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_suspend_state_suspend_sync_star_at_start_offset = 0x240;
+    AOT_ObjectStore_suspend_state_suspend_sync_star_at_start_offset = 0x260;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_suspend_state_yield_async_star_offset = 0x234;
+    AOT_ObjectStore_suspend_state_yield_async_star_offset = 0x254;
 static constexpr dart::compiler::target::word AOT_OneByteString_data_offset =
     0xc;
 static constexpr dart::compiler::target::word AOT_PersistentHandle_ptr_offset =
@@ -19741,55 +19834,53 @@ static constexpr dart::compiler::target::word
 static constexpr dart::compiler::target::word
     AOT_Thread_AllocateArray_entry_point_offset = 0x174;
 static constexpr dart::compiler::target::word
-    AOT_Thread_active_exception_offset = 0x3e8;
+    AOT_Thread_DeoptimizeCopyFrame_entry_point_offset = 0x380;
 static constexpr dart::compiler::target::word
-    AOT_Thread_active_stacktrace_offset = 0x3ec;
+    AOT_Thread_active_exception_offset = 0x360;
+static constexpr dart::compiler::target::word
+    AOT_Thread_active_stacktrace_offset = 0x364;
 static constexpr dart::compiler::target::word
     AOT_Thread_array_write_barrier_entry_point_offset = 0x100;
 static constexpr dart::compiler::target::word
     AOT_Thread_allocate_mint_with_fpu_regs_entry_point_offset = 0x108;
 static constexpr dart::compiler::target::word
-    AOT_Thread_allocate_mint_with_fpu_regs_stub_offset = 0x9c;
+    AOT_Thread_allocate_mint_with_fpu_regs_stub_offset = 0xa8;
 static constexpr dart::compiler::target::word
     AOT_Thread_allocate_mint_without_fpu_regs_entry_point_offset = 0x10c;
 static constexpr dart::compiler::target::word
-    AOT_Thread_allocate_mint_without_fpu_regs_stub_offset = 0xa0;
+    AOT_Thread_allocate_mint_without_fpu_regs_stub_offset = 0xac;
 static constexpr dart::compiler::target::word
     AOT_Thread_allocate_object_entry_point_offset = 0x110;
 static constexpr dart::compiler::target::word
-    AOT_Thread_allocate_object_stub_offset = 0xa4;
-static constexpr dart::compiler::target::word
     AOT_Thread_allocate_object_parameterized_entry_point_offset = 0x114;
 static constexpr dart::compiler::target::word
-    AOT_Thread_allocate_object_parameterized_stub_offset = 0xa8;
-static constexpr dart::compiler::target::word
     AOT_Thread_allocate_object_slow_entry_point_offset = 0x118;
-static constexpr dart::compiler::target::word
-    AOT_Thread_allocate_object_slow_stub_offset = 0xac;
 static constexpr dart::compiler::target::word AOT_Thread_api_top_scope_offset =
-    0x408;
+    0x440;
 static constexpr dart::compiler::target::word
     AOT_Thread_async_exception_handler_stub_offset = 0xb0;
 static constexpr dart::compiler::target::word
     AOT_Thread_auto_scope_native_wrapper_entry_point_offset = 0x14c;
 static constexpr dart::compiler::target::word AOT_Thread_bool_false_offset =
-    0x40;
+    0x4c;
 static constexpr dart::compiler::target::word AOT_Thread_bool_true_offset =
-    0x3c;
+    0x48;
 static constexpr dart::compiler::target::word
     AOT_Thread_bootstrap_native_wrapper_entry_point_offset = 0x144;
 static constexpr dart::compiler::target::word
     AOT_Thread_call_to_runtime_entry_point_offset = 0x104;
 static constexpr dart::compiler::target::word
-    AOT_Thread_call_to_runtime_stub_offset = 0x60;
+    AOT_Thread_call_to_runtime_stub_offset = 0x6c;
 static constexpr dart::compiler::target::word AOT_Thread_dart_stream_offset =
-    0x430;
+    0x47c;
 static constexpr dart::compiler::target::word
-    AOT_Thread_dispatch_table_array_offset = 0x2c;
+    AOT_Thread_dispatch_table_array_offset = 0x34;
 static constexpr dart::compiler::target::word
-    AOT_Thread_double_truncate_round_supported_offset = 0x40c;
+    AOT_Thread_double_truncate_round_supported_offset = 0x444;
 static constexpr dart::compiler::target::word
-    AOT_Thread_service_extension_stream_offset = 0x434;
+    AOT_Thread_service_extension_stream_offset = 0x480;
+static constexpr dart::compiler::target::word AOT_Thread_thread_locals_offset =
+    0x484;
 static constexpr dart::compiler::target::word AOT_Thread_optimize_entry_offset =
     0x12c;
 static constexpr dart::compiler::target::word AOT_Thread_optimize_stub_offset =
@@ -19802,11 +19893,11 @@ static constexpr dart::compiler::target::word
     AOT_Thread_double_abs_address_offset = 0x160;
 static constexpr dart::compiler::target::word
     AOT_Thread_double_negate_address_offset = 0x15c;
-static constexpr dart::compiler::target::word AOT_Thread_end_offset = 0x28;
+static constexpr dart::compiler::target::word AOT_Thread_end_offset = 0x30;
 static constexpr dart::compiler::target::word
     AOT_Thread_enter_safepoint_stub_offset = 0xf0;
 static constexpr dart::compiler::target::word
-    AOT_Thread_execution_state_offset = 0x3fc;
+    AOT_Thread_execution_state_offset = 0x374;
 static constexpr dart::compiler::target::word
     AOT_Thread_exit_safepoint_stub_offset = 0xf4;
 static constexpr dart::compiler::target::word
@@ -19814,9 +19905,9 @@ static constexpr dart::compiler::target::word
 static constexpr dart::compiler::target::word
     AOT_Thread_call_native_through_safepoint_entry_point_offset = 0x134;
 static constexpr dart::compiler::target::word
-    AOT_Thread_fix_allocation_stub_code_offset = 0x54;
+    AOT_Thread_fix_allocation_stub_code_offset = 0x60;
 static constexpr dart::compiler::target::word
-    AOT_Thread_fix_callers_target_code_offset = 0x50;
+    AOT_Thread_fix_callers_target_code_offset = 0x5c;
 static constexpr dart::compiler::target::word
     AOT_Thread_float_absolute_address_offset = 0x16c;
 static constexpr dart::compiler::target::word
@@ -19826,20 +19917,20 @@ static constexpr dart::compiler::target::word
 static constexpr dart::compiler::target::word
     AOT_Thread_float_zerow_address_offset = 0x170;
 static constexpr dart::compiler::target::word
-    AOT_Thread_global_object_pool_offset = 0x3f0;
+    AOT_Thread_global_object_pool_offset = 0x368;
 static constexpr dart::compiler::target::word
     AOT_Thread_interpret_call_entry_point_offset = 0x150;
 static constexpr dart::compiler::target::word
-    AOT_Thread_invoke_dart_code_from_bytecode_stub_offset = 0x5c;
+    AOT_Thread_invoke_dart_code_from_bytecode_stub_offset = 0x68;
 static constexpr dart::compiler::target::word
-    AOT_Thread_invoke_dart_code_stub_offset = 0x58;
+    AOT_Thread_invoke_dart_code_stub_offset = 0x64;
 static constexpr dart::compiler::target::word
-    AOT_Thread_exit_through_ffi_offset = 0x404;
-static constexpr dart::compiler::target::word AOT_Thread_isolate_offset = 0x3b0;
+    AOT_Thread_exit_through_ffi_offset = 0x37c;
+static constexpr dart::compiler::target::word AOT_Thread_isolate_offset = 0x338;
 static constexpr dart::compiler::target::word AOT_Thread_isolate_group_offset =
-    0x3b4;
+    0x33c;
 static constexpr dart::compiler::target::word
-    AOT_Thread_field_table_values_offset = 0x30;
+    AOT_Thread_field_table_values_offset = 0x38;
 static constexpr dart::compiler::target::word
     AOT_Thread_lazy_deopt_from_return_stub_offset = 0xe0;
 static constexpr dart::compiler::target::word
@@ -19847,9 +19938,9 @@ static constexpr dart::compiler::target::word
 static constexpr dart::compiler::target::word
     AOT_Thread_lazy_specialize_type_test_stub_offset = 0xec;
 static constexpr dart::compiler::target::word
-    AOT_Thread_old_marking_stack_block_offset = 0x3c8;
+    AOT_Thread_old_marking_stack_block_offset = 0x350;
 static constexpr dart::compiler::target::word
-    AOT_Thread_new_marking_stack_block_offset = 0x3cc;
+    AOT_Thread_new_marking_stack_block_offset = 0x354;
 static constexpr dart::compiler::target::word
     AOT_Thread_megamorphic_call_checked_entry_offset = 0x124;
 static constexpr dart::compiler::target::word
@@ -19860,34 +19951,34 @@ static constexpr dart::compiler::target::word
     AOT_Thread_no_scope_native_wrapper_entry_point_offset = 0x148;
 static constexpr dart::compiler::target::word
     AOT_Thread_late_initialization_error_shared_with_fpu_regs_stub_offset =
-        0x68;
+        0x74;
 static constexpr dart::compiler::target::word
     AOT_Thread_late_initialization_error_shared_without_fpu_regs_stub_offset =
-        0x64;
+        0x70;
 static constexpr dart::compiler::target::word
-    AOT_Thread_null_error_shared_with_fpu_regs_stub_offset = 0x70;
+    AOT_Thread_null_error_shared_with_fpu_regs_stub_offset = 0x7c;
 static constexpr dart::compiler::target::word
-    AOT_Thread_null_error_shared_without_fpu_regs_stub_offset = 0x6c;
+    AOT_Thread_null_error_shared_without_fpu_regs_stub_offset = 0x78;
 static constexpr dart::compiler::target::word
-    AOT_Thread_null_arg_error_shared_with_fpu_regs_stub_offset = 0x78;
+    AOT_Thread_null_arg_error_shared_with_fpu_regs_stub_offset = 0x84;
 static constexpr dart::compiler::target::word
-    AOT_Thread_null_arg_error_shared_without_fpu_regs_stub_offset = 0x74;
+    AOT_Thread_null_arg_error_shared_without_fpu_regs_stub_offset = 0x80;
 static constexpr dart::compiler::target::word
-    AOT_Thread_null_cast_error_shared_with_fpu_regs_stub_offset = 0x80;
+    AOT_Thread_null_cast_error_shared_with_fpu_regs_stub_offset = 0x8c;
 static constexpr dart::compiler::target::word
-    AOT_Thread_null_cast_error_shared_without_fpu_regs_stub_offset = 0x7c;
+    AOT_Thread_null_cast_error_shared_without_fpu_regs_stub_offset = 0x88;
 static constexpr dart::compiler::target::word
-    AOT_Thread_range_error_shared_with_fpu_regs_stub_offset = 0x88;
+    AOT_Thread_range_error_shared_with_fpu_regs_stub_offset = 0x94;
 static constexpr dart::compiler::target::word
-    AOT_Thread_range_error_shared_without_fpu_regs_stub_offset = 0x84;
+    AOT_Thread_range_error_shared_without_fpu_regs_stub_offset = 0x90;
 static constexpr dart::compiler::target::word
-    AOT_Thread_write_error_shared_with_fpu_regs_stub_offset = 0x90;
+    AOT_Thread_write_error_shared_with_fpu_regs_stub_offset = 0x9c;
 static constexpr dart::compiler::target::word
-    AOT_Thread_write_error_shared_without_fpu_regs_stub_offset = 0x8c;
+    AOT_Thread_write_error_shared_without_fpu_regs_stub_offset = 0x98;
 static constexpr dart::compiler::target::word
-    AOT_Thread_field_access_error_shared_with_fpu_regs_stub_offset = 0x98;
+    AOT_Thread_field_access_error_shared_with_fpu_regs_stub_offset = 0xa4;
 static constexpr dart::compiler::target::word
-    AOT_Thread_field_access_error_shared_without_fpu_regs_stub_offset = 0x94;
+    AOT_Thread_field_access_error_shared_without_fpu_regs_stub_offset = 0xa0;
 static constexpr dart::compiler::target::word AOT_Thread_resume_stub_offset =
     0xb4;
 static constexpr dart::compiler::target::word
@@ -19897,31 +19988,31 @@ static constexpr dart::compiler::target::word
 static constexpr dart::compiler::target::word
     AOT_Thread_return_async_stub_offset = 0xb8;
 static constexpr dart::compiler::target::word AOT_Thread_object_null_offset =
-    0x38;
+    0x40;
 static constexpr dart::compiler::target::word
     AOT_Thread_predefined_symbols_address_offset = 0x154;
 static constexpr dart::compiler::target::word
     AOT_Thread_resume_interpreter_adjusted_entry_point_offset = 0x140;
 static constexpr dart::compiler::target::word AOT_Thread_resume_pc_offset =
-    0x3f4;
+    0x36c;
 static constexpr dart::compiler::target::word
-    AOT_Thread_saved_shadow_call_stack_offset = 0x3f8;
+    AOT_Thread_saved_shadow_call_stack_offset = 0x370;
 static constexpr dart::compiler::target::word
-    AOT_Thread_safepoint_state_offset = 0x400;
+    AOT_Thread_safepoint_state_offset = 0x378;
 static constexpr dart::compiler::target::word
-    AOT_Thread_shared_field_table_values_offset = 0x34;
+    AOT_Thread_shared_field_table_values_offset = 0x3c;
 static constexpr dart::compiler::target::word AOT_Thread_single_step_offset =
-    0x424;
+    0x46c;
 static constexpr dart::compiler::target::word
     AOT_Thread_slow_type_test_stub_offset = 0xe8;
 static constexpr dart::compiler::target::word
     AOT_Thread_slow_type_test_entry_point_offset = 0x13c;
 static constexpr dart::compiler::target::word AOT_Thread_stack_limit_offset =
-    0x1c;
+    0x24;
 static constexpr dart::compiler::target::word
-    AOT_Thread_saved_stack_limit_offset = 0x3b8;
+    AOT_Thread_saved_stack_limit_offset = 0x340;
 static constexpr dart::compiler::target::word
-    AOT_Thread_stack_overflow_flags_offset = 0x3bc;
+    AOT_Thread_stack_overflow_flags_offset = 0x344;
 static constexpr dart::compiler::target::word
     AOT_Thread_stack_overflow_shared_with_fpu_regs_entry_point_offset = 0x120;
 static constexpr dart::compiler::target::word
@@ -19932,49 +20023,55 @@ static constexpr dart::compiler::target::word
 static constexpr dart::compiler::target::word
     AOT_Thread_stack_overflow_shared_without_fpu_regs_stub_offset = 0xc4;
 static constexpr dart::compiler::target::word
-    AOT_Thread_store_buffer_block_offset = 0x3c4;
+    AOT_Thread_store_buffer_block_offset = 0x34c;
 static constexpr dart::compiler::target::word
-    AOT_Thread_suspend_state_await_entry_point_offset = 0x388;
+    AOT_Thread_suspend_state_await_entry_point_offset = 0x310;
 static constexpr dart::compiler::target::word
-    AOT_Thread_suspend_state_await_with_type_check_entry_point_offset = 0x38c;
+    AOT_Thread_suspend_state_await_with_type_check_entry_point_offset = 0x314;
 static constexpr dart::compiler::target::word
-    AOT_Thread_suspend_state_init_async_entry_point_offset = 0x384;
+    AOT_Thread_suspend_state_init_async_entry_point_offset = 0x30c;
 static constexpr dart::compiler::target::word
-    AOT_Thread_suspend_state_return_async_entry_point_offset = 0x390;
+    AOT_Thread_suspend_state_return_async_entry_point_offset = 0x318;
 static constexpr dart::compiler::target::word
-    AOT_Thread_suspend_state_return_async_not_future_entry_point_offset = 0x394;
+    AOT_Thread_suspend_state_return_async_not_future_entry_point_offset = 0x31c;
 static constexpr dart::compiler::target::word
-    AOT_Thread_suspend_state_init_async_star_entry_point_offset = 0x398;
+    AOT_Thread_suspend_state_init_async_star_entry_point_offset = 0x320;
 static constexpr dart::compiler::target::word
-    AOT_Thread_suspend_state_yield_async_star_entry_point_offset = 0x39c;
+    AOT_Thread_suspend_state_yield_async_star_entry_point_offset = 0x324;
 static constexpr dart::compiler::target::word
-    AOT_Thread_suspend_state_return_async_star_entry_point_offset = 0x3a0;
+    AOT_Thread_suspend_state_return_async_star_entry_point_offset = 0x328;
 static constexpr dart::compiler::target::word
-    AOT_Thread_suspend_state_init_sync_star_entry_point_offset = 0x3a4;
+    AOT_Thread_suspend_state_init_sync_star_entry_point_offset = 0x32c;
 static constexpr dart::compiler::target::word
     AOT_Thread_suspend_state_suspend_sync_star_at_start_entry_point_offset =
-        0x3a8;
+        0x330;
 static constexpr dart::compiler::target::word
-    AOT_Thread_suspend_state_handle_exception_entry_point_offset = 0x3ac;
+    AOT_Thread_suspend_state_handle_exception_entry_point_offset = 0x334;
 static constexpr dart::compiler::target::word
-    AOT_Thread_top_exit_frame_info_offset = 0x3c0;
-static constexpr dart::compiler::target::word AOT_Thread_top_offset = 0x24;
+    AOT_Thread_top_exit_frame_info_offset = 0x348;
+static constexpr dart::compiler::target::word AOT_Thread_top_offset = 0x2c;
 static constexpr dart::compiler::target::word AOT_Thread_top_resource_offset =
     0x10;
 static constexpr dart::compiler::target::word
-    AOT_Thread_unboxed_runtime_arg_offset = 0x3d8;
-static constexpr dart::compiler::target::word AOT_Thread_vm_tag_offset = 0x3d4;
+    AOT_Thread_unboxed_runtime_arg_offset = 0x448;
+static constexpr dart::compiler::target::word AOT_Thread_vm_tag_offset = 0x35c;
 static constexpr dart::compiler::target::word
     AOT_Thread_write_barrier_entry_point_offset = 0xfc;
 static constexpr dart::compiler::target::word
-    AOT_Thread_write_barrier_mask_offset = 0x20;
+    AOT_Thread_write_barrier_mask_offset = 0x28;
 static constexpr dart::compiler::target::word AOT_Thread_next_task_id_offset =
-    0x410;
-static constexpr dart::compiler::target::word AOT_Thread_random_offset = 0x418;
+    0x458;
+static constexpr dart::compiler::target::word AOT_Thread_random_offset = 0x460;
 static constexpr dart::compiler::target::word
     AOT_Thread_jump_to_frame_entry_point_offset = 0x138;
 static constexpr dart::compiler::target::word AOT_Thread_tsan_utils_offset =
-    0x420;
+    0x468;
+static constexpr dart::compiler::target::word AOT_Thread_current_tag_offset =
+    0x474;
+static constexpr dart::compiler::target::word AOT_Thread_default_tag_offset =
+    0x478;
+static constexpr dart::compiler::target::word AOT_Thread_user_tag_offset =
+    0x470;
 static constexpr dart::compiler::target::word
     AOT_TsanUtils_setjmp_function_offset = 0x0;
 static constexpr dart::compiler::target::word
@@ -20074,9 +20171,9 @@ static constexpr dart::compiler::target::word AOT_Code_entry_point_offset[] = {
     0x4, 0xc, 0x8, 0x10};
 static constexpr dart::compiler::target::word
     AOT_Thread_write_barrier_wrappers_thread_offset[] = {
-        -1,    -1,    0x338, 0x33c, 0x340, 0x344, 0x348, 0x34c,
-        0x350, 0x354, 0x358, 0x35c, 0x360, 0x364, 0x368, 0x36c,
-        0x370, 0x374, 0x378, -1,    0x37c, 0x380, -1,    -1,
+        -1,    -1,    0x2c0, 0x2c4, 0x2c8, 0x2cc, 0x2d0, 0x2d4,
+        0x2d8, 0x2dc, 0x2e0, 0x2e4, 0x2e8, 0x2ec, 0x2f0, 0x2f4,
+        0x2f8, 0x2fc, 0x300, -1,    0x304, 0x308, -1,    -1,
         -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1};
 static constexpr dart::compiler::target::word AOT_AbstractType_InstanceSize =
     0x14;
@@ -20104,7 +20201,7 @@ static constexpr dart::compiler::target::word
     AOT_ExternalTypedData_InstanceSize = 0xc;
 static constexpr dart::compiler::target::word
     AOT_FfiTrampolineData_InstanceSize = 0x1c;
-static constexpr dart::compiler::target::word AOT_Field_InstanceSize = 0x34;
+static constexpr dart::compiler::target::word AOT_Field_InstanceSize = 0x38;
 static constexpr dart::compiler::target::word AOT_Finalizer_InstanceSize = 0x1c;
 static constexpr dart::compiler::target::word AOT_FinalizerEntry_InstanceSize =
     0x20;
@@ -20194,7 +20291,7 @@ static constexpr dart::compiler::target::word AOT_UnlinkedCall_InstanceSize =
     0x10;
 static constexpr dart::compiler::target::word AOT_UnwindError_InstanceSize =
     0xc;
-static constexpr dart::compiler::target::word AOT_UserTag_InstanceSize = 0x10;
+static constexpr dart::compiler::target::word AOT_UserTag_InstanceSize = 0xc;
 static constexpr dart::compiler::target::word AOT_WeakProperty_InstanceSize =
     0x10;
 static constexpr dart::compiler::target::word AOT_WeakReference_InstanceSize =
@@ -26083,6 +26180,8 @@ static constexpr dart::compiler::target::word AOT_Array_kMaxNewSpaceElements =
     0xfffd;
 static constexpr dart::compiler::target::word AOT_Context_kMaxElements =
     0xfffffff;
+static constexpr dart::compiler::target::word AOT_Heap_kNewAllocatableSize =
+    0x40000;
 static constexpr dart::compiler::target::word
     AOT_Instructions_kMonomorphicEntryOffsetJIT = 0xc;
 static constexpr dart::compiler::target::word
@@ -26098,6 +26197,7 @@ static constexpr dart::compiler::target::word
 static constexpr dart::compiler::target::word
     AOT_NativeEntry_kNumCallWrapperArguments = 0x2;
 static constexpr dart::compiler::target::word AOT_Page_kBytesPerCardLog2 = 0x7;
+static constexpr dart::compiler::target::word AOT_Page_kPageMask = -0x80000;
 static constexpr dart::compiler::target::word AOT_Record_kMaxElements = 0xffff;
 static constexpr dart::compiler::target::word
     AOT_RecordShape_kFieldNamesIndexMask = 0x3fff;
@@ -26137,6 +26237,36 @@ static constexpr dart::compiler::target::word AOT_SubtypeTestCache_kTestResult =
     0x7;
 static constexpr dart::compiler::target::word AOT_TypeArguments_kMaxElements =
     0xfffffff;
+static constexpr dart::compiler::target::word
+    AOT_UntaggedObject_kCardRememberedBit = 0x0;
+static constexpr dart::compiler::target::word AOT_UntaggedObject_kCanonicalBit =
+    0x1;
+static constexpr dart::compiler::target::word AOT_UntaggedObject_kNotMarkedBit =
+    0x2;
+static constexpr dart::compiler::target::word
+    AOT_UntaggedObject_kNewOrEvacuationCandidateBit = 0x3;
+static constexpr dart::compiler::target::word AOT_UntaggedObject_kAlwaysSetBit =
+    0x4;
+static constexpr dart::compiler::target::word
+    AOT_UntaggedObject_kOldAndNotRememberedBit = 0x5;
+static constexpr dart::compiler::target::word
+    AOT_UntaggedObject_kIncrementalBarrierMask = 0x4;
+static constexpr dart::compiler::target::word
+    AOT_UntaggedObject_kGenerationalBarrierMask = 0x8;
+static constexpr dart::compiler::target::word
+    AOT_UntaggedObject_kBarrierOverlapShift = 0x2;
+static constexpr dart::compiler::target::word
+    AOT_UntaggedObject_kShallowImmutableBit = 0x6;
+static constexpr dart::compiler::target::word
+    AOT_UntaggedObject_kDeeplyImmutableBit = 0x7;
+static constexpr dart::compiler::target::word AOT_UntaggedObject_kSizeTagPos =
+    0x8;
+static constexpr dart::compiler::target::word AOT_UntaggedObject_kSizeTagSize =
+    0x4;
+static constexpr dart::compiler::target::word
+    AOT_UntaggedObject_kClassIdTagPos = 0xc;
+static constexpr dart::compiler::target::word
+    AOT_UntaggedObject_kClassIdTagSize = 0x14;
 static constexpr dart::compiler::target::word AOT_AbstractType_flags_offset =
     0x8;
 static constexpr dart::compiler::target::word AOT_AbstractType_hash_offset =
@@ -26207,7 +26337,7 @@ static constexpr dart::compiler::target::word
     AOT_Field_guarded_list_length_offset = 0x18;
 static constexpr dart::compiler::target::word AOT_Field_is_nullable_offset =
     0x2c;
-static constexpr dart::compiler::target::word AOT_Field_kind_bits_offset = 0x32;
+static constexpr dart::compiler::target::word AOT_Field_kind_bits_offset = 0x34;
 static constexpr dart::compiler::target::word AOT_Function_code_offset = 0x20;
 static constexpr dart::compiler::target::word AOT_Function_data_offset = 0x18;
 static constexpr dart::compiler::target::word
@@ -26239,20 +26369,17 @@ static constexpr dart::compiler::target::word AOT_ICData_entries_offset = 0xc;
 static constexpr dart::compiler::target::word AOT_ICData_owner_offset = 0x10;
 static constexpr dart::compiler::target::word AOT_ICData_state_bits_offset =
     0x14;
+static constexpr dart::compiler::target::word AOT_Instance_first_field_offset =
+    0x4;
 static constexpr dart::compiler::target::word AOT_Int32x4_value_offset = 0x8;
-static constexpr dart::compiler::target::word AOT_Isolate_current_tag_offset =
-    0xc;
-static constexpr dart::compiler::target::word AOT_Isolate_default_tag_offset =
-    0x10;
 static constexpr dart::compiler::target::word AOT_Isolate_finalizers_offset =
-    0x18;
+    0xc;
 static constexpr dart::compiler::target::word
     AOT_IsolateGroup_object_store_offset = 0x10;
 static constexpr dart::compiler::target::word
     AOT_IsolateGroup_class_table_offset = 0x8;
 static constexpr dart::compiler::target::word
     AOT_IsolateGroup_cached_class_table_table_offset = 0xc;
-static constexpr dart::compiler::target::word AOT_Isolate_user_tag_offset = 0x8;
 static constexpr dart::compiler::target::word AOT_LinkedHashBase_data_offset =
     0xc;
 static constexpr dart::compiler::target::word
@@ -26285,40 +26412,41 @@ static constexpr dart::compiler::target::word
     AOT_NativeArguments_retval_offset = 0xc;
 static constexpr dart::compiler::target::word
     AOT_NativeArguments_thread_offset = 0x0;
+static constexpr dart::compiler::target::word AOT_Object_tags_offset = 0x0;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_double_type_offset = 0xc0;
+    AOT_ObjectStore_double_type_offset = 0xdc;
 static constexpr dart::compiler::target::word AOT_ObjectStore_int_type_offset =
-    0x98;
+    0xb4;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_record_field_names_offset = 0x1f8;
+    AOT_ObjectStore_record_field_names_offset = 0x218;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_string_type_offset = 0xd4;
+    AOT_ObjectStore_string_type_offset = 0xf0;
 static constexpr dart::compiler::target::word AOT_ObjectStore_type_type_offset =
-    0x84;
+    0xa0;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_ffi_callback_code_offset = 0x274;
+    AOT_ObjectStore_ffi_callback_code_offset = 0x294;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_suspend_state_await_offset = 0x220;
+    AOT_ObjectStore_suspend_state_await_offset = 0x240;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_suspend_state_await_with_type_check_offset = 0x224;
+    AOT_ObjectStore_suspend_state_await_with_type_check_offset = 0x244;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_suspend_state_handle_exception_offset = 0x244;
+    AOT_ObjectStore_suspend_state_handle_exception_offset = 0x264;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_suspend_state_init_async_offset = 0x21c;
+    AOT_ObjectStore_suspend_state_init_async_offset = 0x23c;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_suspend_state_init_async_star_offset = 0x230;
+    AOT_ObjectStore_suspend_state_init_async_star_offset = 0x250;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_suspend_state_init_sync_star_offset = 0x23c;
+    AOT_ObjectStore_suspend_state_init_sync_star_offset = 0x25c;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_suspend_state_return_async_offset = 0x228;
+    AOT_ObjectStore_suspend_state_return_async_offset = 0x248;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_suspend_state_return_async_not_future_offset = 0x22c;
+    AOT_ObjectStore_suspend_state_return_async_not_future_offset = 0x24c;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_suspend_state_return_async_star_offset = 0x238;
+    AOT_ObjectStore_suspend_state_return_async_star_offset = 0x258;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_suspend_state_suspend_sync_star_at_start_offset = 0x240;
+    AOT_ObjectStore_suspend_state_suspend_sync_star_at_start_offset = 0x260;
 static constexpr dart::compiler::target::word
-    AOT_ObjectStore_suspend_state_yield_async_star_offset = 0x234;
+    AOT_ObjectStore_suspend_state_yield_async_star_offset = 0x254;
 static constexpr dart::compiler::target::word AOT_OneByteString_data_offset =
     0xc;
 static constexpr dart::compiler::target::word AOT_PersistentHandle_ptr_offset =
@@ -26367,55 +26495,53 @@ static constexpr dart::compiler::target::word
 static constexpr dart::compiler::target::word
     AOT_Thread_AllocateArray_entry_point_offset = 0x174;
 static constexpr dart::compiler::target::word
-    AOT_Thread_active_exception_offset = 0x3e8;
+    AOT_Thread_DeoptimizeCopyFrame_entry_point_offset = 0x380;
 static constexpr dart::compiler::target::word
-    AOT_Thread_active_stacktrace_offset = 0x3ec;
+    AOT_Thread_active_exception_offset = 0x360;
+static constexpr dart::compiler::target::word
+    AOT_Thread_active_stacktrace_offset = 0x364;
 static constexpr dart::compiler::target::word
     AOT_Thread_array_write_barrier_entry_point_offset = 0x100;
 static constexpr dart::compiler::target::word
     AOT_Thread_allocate_mint_with_fpu_regs_entry_point_offset = 0x108;
 static constexpr dart::compiler::target::word
-    AOT_Thread_allocate_mint_with_fpu_regs_stub_offset = 0x9c;
+    AOT_Thread_allocate_mint_with_fpu_regs_stub_offset = 0xa8;
 static constexpr dart::compiler::target::word
     AOT_Thread_allocate_mint_without_fpu_regs_entry_point_offset = 0x10c;
 static constexpr dart::compiler::target::word
-    AOT_Thread_allocate_mint_without_fpu_regs_stub_offset = 0xa0;
+    AOT_Thread_allocate_mint_without_fpu_regs_stub_offset = 0xac;
 static constexpr dart::compiler::target::word
     AOT_Thread_allocate_object_entry_point_offset = 0x110;
 static constexpr dart::compiler::target::word
-    AOT_Thread_allocate_object_stub_offset = 0xa4;
-static constexpr dart::compiler::target::word
     AOT_Thread_allocate_object_parameterized_entry_point_offset = 0x114;
 static constexpr dart::compiler::target::word
-    AOT_Thread_allocate_object_parameterized_stub_offset = 0xa8;
-static constexpr dart::compiler::target::word
     AOT_Thread_allocate_object_slow_entry_point_offset = 0x118;
-static constexpr dart::compiler::target::word
-    AOT_Thread_allocate_object_slow_stub_offset = 0xac;
 static constexpr dart::compiler::target::word AOT_Thread_api_top_scope_offset =
-    0x408;
+    0x440;
 static constexpr dart::compiler::target::word
     AOT_Thread_async_exception_handler_stub_offset = 0xb0;
 static constexpr dart::compiler::target::word
     AOT_Thread_auto_scope_native_wrapper_entry_point_offset = 0x14c;
 static constexpr dart::compiler::target::word AOT_Thread_bool_false_offset =
-    0x40;
+    0x4c;
 static constexpr dart::compiler::target::word AOT_Thread_bool_true_offset =
-    0x3c;
+    0x48;
 static constexpr dart::compiler::target::word
     AOT_Thread_bootstrap_native_wrapper_entry_point_offset = 0x144;
 static constexpr dart::compiler::target::word
     AOT_Thread_call_to_runtime_entry_point_offset = 0x104;
 static constexpr dart::compiler::target::word
-    AOT_Thread_call_to_runtime_stub_offset = 0x60;
+    AOT_Thread_call_to_runtime_stub_offset = 0x6c;
 static constexpr dart::compiler::target::word AOT_Thread_dart_stream_offset =
-    0x430;
+    0x47c;
 static constexpr dart::compiler::target::word
-    AOT_Thread_dispatch_table_array_offset = 0x2c;
+    AOT_Thread_dispatch_table_array_offset = 0x34;
 static constexpr dart::compiler::target::word
-    AOT_Thread_double_truncate_round_supported_offset = 0x40c;
+    AOT_Thread_double_truncate_round_supported_offset = 0x444;
 static constexpr dart::compiler::target::word
-    AOT_Thread_service_extension_stream_offset = 0x434;
+    AOT_Thread_service_extension_stream_offset = 0x480;
+static constexpr dart::compiler::target::word AOT_Thread_thread_locals_offset =
+    0x484;
 static constexpr dart::compiler::target::word AOT_Thread_optimize_entry_offset =
     0x12c;
 static constexpr dart::compiler::target::word AOT_Thread_optimize_stub_offset =
@@ -26428,11 +26554,11 @@ static constexpr dart::compiler::target::word
     AOT_Thread_double_abs_address_offset = 0x160;
 static constexpr dart::compiler::target::word
     AOT_Thread_double_negate_address_offset = 0x15c;
-static constexpr dart::compiler::target::word AOT_Thread_end_offset = 0x28;
+static constexpr dart::compiler::target::word AOT_Thread_end_offset = 0x30;
 static constexpr dart::compiler::target::word
     AOT_Thread_enter_safepoint_stub_offset = 0xf0;
 static constexpr dart::compiler::target::word
-    AOT_Thread_execution_state_offset = 0x3fc;
+    AOT_Thread_execution_state_offset = 0x374;
 static constexpr dart::compiler::target::word
     AOT_Thread_exit_safepoint_stub_offset = 0xf4;
 static constexpr dart::compiler::target::word
@@ -26440,9 +26566,9 @@ static constexpr dart::compiler::target::word
 static constexpr dart::compiler::target::word
     AOT_Thread_call_native_through_safepoint_entry_point_offset = 0x134;
 static constexpr dart::compiler::target::word
-    AOT_Thread_fix_allocation_stub_code_offset = 0x54;
+    AOT_Thread_fix_allocation_stub_code_offset = 0x60;
 static constexpr dart::compiler::target::word
-    AOT_Thread_fix_callers_target_code_offset = 0x50;
+    AOT_Thread_fix_callers_target_code_offset = 0x5c;
 static constexpr dart::compiler::target::word
     AOT_Thread_float_absolute_address_offset = 0x16c;
 static constexpr dart::compiler::target::word
@@ -26452,20 +26578,20 @@ static constexpr dart::compiler::target::word
 static constexpr dart::compiler::target::word
     AOT_Thread_float_zerow_address_offset = 0x170;
 static constexpr dart::compiler::target::word
-    AOT_Thread_global_object_pool_offset = 0x3f0;
+    AOT_Thread_global_object_pool_offset = 0x368;
 static constexpr dart::compiler::target::word
     AOT_Thread_interpret_call_entry_point_offset = 0x150;
 static constexpr dart::compiler::target::word
-    AOT_Thread_invoke_dart_code_from_bytecode_stub_offset = 0x5c;
+    AOT_Thread_invoke_dart_code_from_bytecode_stub_offset = 0x68;
 static constexpr dart::compiler::target::word
-    AOT_Thread_invoke_dart_code_stub_offset = 0x58;
+    AOT_Thread_invoke_dart_code_stub_offset = 0x64;
 static constexpr dart::compiler::target::word
-    AOT_Thread_exit_through_ffi_offset = 0x404;
-static constexpr dart::compiler::target::word AOT_Thread_isolate_offset = 0x3b0;
+    AOT_Thread_exit_through_ffi_offset = 0x37c;
+static constexpr dart::compiler::target::word AOT_Thread_isolate_offset = 0x338;
 static constexpr dart::compiler::target::word AOT_Thread_isolate_group_offset =
-    0x3b4;
+    0x33c;
 static constexpr dart::compiler::target::word
-    AOT_Thread_field_table_values_offset = 0x30;
+    AOT_Thread_field_table_values_offset = 0x38;
 static constexpr dart::compiler::target::word
     AOT_Thread_lazy_deopt_from_return_stub_offset = 0xe0;
 static constexpr dart::compiler::target::word
@@ -26473,9 +26599,9 @@ static constexpr dart::compiler::target::word
 static constexpr dart::compiler::target::word
     AOT_Thread_lazy_specialize_type_test_stub_offset = 0xec;
 static constexpr dart::compiler::target::word
-    AOT_Thread_old_marking_stack_block_offset = 0x3c8;
+    AOT_Thread_old_marking_stack_block_offset = 0x350;
 static constexpr dart::compiler::target::word
-    AOT_Thread_new_marking_stack_block_offset = 0x3cc;
+    AOT_Thread_new_marking_stack_block_offset = 0x354;
 static constexpr dart::compiler::target::word
     AOT_Thread_megamorphic_call_checked_entry_offset = 0x124;
 static constexpr dart::compiler::target::word
@@ -26486,34 +26612,34 @@ static constexpr dart::compiler::target::word
     AOT_Thread_no_scope_native_wrapper_entry_point_offset = 0x148;
 static constexpr dart::compiler::target::word
     AOT_Thread_late_initialization_error_shared_with_fpu_regs_stub_offset =
-        0x68;
+        0x74;
 static constexpr dart::compiler::target::word
     AOT_Thread_late_initialization_error_shared_without_fpu_regs_stub_offset =
-        0x64;
+        0x70;
 static constexpr dart::compiler::target::word
-    AOT_Thread_null_error_shared_with_fpu_regs_stub_offset = 0x70;
+    AOT_Thread_null_error_shared_with_fpu_regs_stub_offset = 0x7c;
 static constexpr dart::compiler::target::word
-    AOT_Thread_null_error_shared_without_fpu_regs_stub_offset = 0x6c;
+    AOT_Thread_null_error_shared_without_fpu_regs_stub_offset = 0x78;
 static constexpr dart::compiler::target::word
-    AOT_Thread_null_arg_error_shared_with_fpu_regs_stub_offset = 0x78;
+    AOT_Thread_null_arg_error_shared_with_fpu_regs_stub_offset = 0x84;
 static constexpr dart::compiler::target::word
-    AOT_Thread_null_arg_error_shared_without_fpu_regs_stub_offset = 0x74;
+    AOT_Thread_null_arg_error_shared_without_fpu_regs_stub_offset = 0x80;
 static constexpr dart::compiler::target::word
-    AOT_Thread_null_cast_error_shared_with_fpu_regs_stub_offset = 0x80;
+    AOT_Thread_null_cast_error_shared_with_fpu_regs_stub_offset = 0x8c;
 static constexpr dart::compiler::target::word
-    AOT_Thread_null_cast_error_shared_without_fpu_regs_stub_offset = 0x7c;
+    AOT_Thread_null_cast_error_shared_without_fpu_regs_stub_offset = 0x88;
 static constexpr dart::compiler::target::word
-    AOT_Thread_range_error_shared_with_fpu_regs_stub_offset = 0x88;
+    AOT_Thread_range_error_shared_with_fpu_regs_stub_offset = 0x94;
 static constexpr dart::compiler::target::word
-    AOT_Thread_range_error_shared_without_fpu_regs_stub_offset = 0x84;
+    AOT_Thread_range_error_shared_without_fpu_regs_stub_offset = 0x90;
 static constexpr dart::compiler::target::word
-    AOT_Thread_write_error_shared_with_fpu_regs_stub_offset = 0x90;
+    AOT_Thread_write_error_shared_with_fpu_regs_stub_offset = 0x9c;
 static constexpr dart::compiler::target::word
-    AOT_Thread_write_error_shared_without_fpu_regs_stub_offset = 0x8c;
+    AOT_Thread_write_error_shared_without_fpu_regs_stub_offset = 0x98;
 static constexpr dart::compiler::target::word
-    AOT_Thread_field_access_error_shared_with_fpu_regs_stub_offset = 0x98;
+    AOT_Thread_field_access_error_shared_with_fpu_regs_stub_offset = 0xa4;
 static constexpr dart::compiler::target::word
-    AOT_Thread_field_access_error_shared_without_fpu_regs_stub_offset = 0x94;
+    AOT_Thread_field_access_error_shared_without_fpu_regs_stub_offset = 0xa0;
 static constexpr dart::compiler::target::word AOT_Thread_resume_stub_offset =
     0xb4;
 static constexpr dart::compiler::target::word
@@ -26523,29 +26649,29 @@ static constexpr dart::compiler::target::word
 static constexpr dart::compiler::target::word
     AOT_Thread_return_async_stub_offset = 0xb8;
 static constexpr dart::compiler::target::word AOT_Thread_object_null_offset =
-    0x38;
+    0x40;
 static constexpr dart::compiler::target::word
     AOT_Thread_predefined_symbols_address_offset = 0x154;
 static constexpr dart::compiler::target::word
     AOT_Thread_resume_interpreter_adjusted_entry_point_offset = 0x140;
 static constexpr dart::compiler::target::word AOT_Thread_resume_pc_offset =
-    0x3f4;
+    0x36c;
 static constexpr dart::compiler::target::word
-    AOT_Thread_saved_shadow_call_stack_offset = 0x3f8;
+    AOT_Thread_saved_shadow_call_stack_offset = 0x370;
 static constexpr dart::compiler::target::word
-    AOT_Thread_safepoint_state_offset = 0x400;
+    AOT_Thread_safepoint_state_offset = 0x378;
 static constexpr dart::compiler::target::word
-    AOT_Thread_shared_field_table_values_offset = 0x34;
+    AOT_Thread_shared_field_table_values_offset = 0x3c;
 static constexpr dart::compiler::target::word
     AOT_Thread_slow_type_test_stub_offset = 0xe8;
 static constexpr dart::compiler::target::word
     AOT_Thread_slow_type_test_entry_point_offset = 0x13c;
 static constexpr dart::compiler::target::word AOT_Thread_stack_limit_offset =
-    0x1c;
+    0x24;
 static constexpr dart::compiler::target::word
-    AOT_Thread_saved_stack_limit_offset = 0x3b8;
+    AOT_Thread_saved_stack_limit_offset = 0x340;
 static constexpr dart::compiler::target::word
-    AOT_Thread_stack_overflow_flags_offset = 0x3bc;
+    AOT_Thread_stack_overflow_flags_offset = 0x344;
 static constexpr dart::compiler::target::word
     AOT_Thread_stack_overflow_shared_with_fpu_regs_entry_point_offset = 0x120;
 static constexpr dart::compiler::target::word
@@ -26556,49 +26682,55 @@ static constexpr dart::compiler::target::word
 static constexpr dart::compiler::target::word
     AOT_Thread_stack_overflow_shared_without_fpu_regs_stub_offset = 0xc4;
 static constexpr dart::compiler::target::word
-    AOT_Thread_store_buffer_block_offset = 0x3c4;
+    AOT_Thread_store_buffer_block_offset = 0x34c;
 static constexpr dart::compiler::target::word
-    AOT_Thread_suspend_state_await_entry_point_offset = 0x388;
+    AOT_Thread_suspend_state_await_entry_point_offset = 0x310;
 static constexpr dart::compiler::target::word
-    AOT_Thread_suspend_state_await_with_type_check_entry_point_offset = 0x38c;
+    AOT_Thread_suspend_state_await_with_type_check_entry_point_offset = 0x314;
 static constexpr dart::compiler::target::word
-    AOT_Thread_suspend_state_init_async_entry_point_offset = 0x384;
+    AOT_Thread_suspend_state_init_async_entry_point_offset = 0x30c;
 static constexpr dart::compiler::target::word
-    AOT_Thread_suspend_state_return_async_entry_point_offset = 0x390;
+    AOT_Thread_suspend_state_return_async_entry_point_offset = 0x318;
 static constexpr dart::compiler::target::word
-    AOT_Thread_suspend_state_return_async_not_future_entry_point_offset = 0x394;
+    AOT_Thread_suspend_state_return_async_not_future_entry_point_offset = 0x31c;
 static constexpr dart::compiler::target::word
-    AOT_Thread_suspend_state_init_async_star_entry_point_offset = 0x398;
+    AOT_Thread_suspend_state_init_async_star_entry_point_offset = 0x320;
 static constexpr dart::compiler::target::word
-    AOT_Thread_suspend_state_yield_async_star_entry_point_offset = 0x39c;
+    AOT_Thread_suspend_state_yield_async_star_entry_point_offset = 0x324;
 static constexpr dart::compiler::target::word
-    AOT_Thread_suspend_state_return_async_star_entry_point_offset = 0x3a0;
+    AOT_Thread_suspend_state_return_async_star_entry_point_offset = 0x328;
 static constexpr dart::compiler::target::word
-    AOT_Thread_suspend_state_init_sync_star_entry_point_offset = 0x3a4;
+    AOT_Thread_suspend_state_init_sync_star_entry_point_offset = 0x32c;
 static constexpr dart::compiler::target::word
     AOT_Thread_suspend_state_suspend_sync_star_at_start_entry_point_offset =
-        0x3a8;
+        0x330;
 static constexpr dart::compiler::target::word
-    AOT_Thread_suspend_state_handle_exception_entry_point_offset = 0x3ac;
+    AOT_Thread_suspend_state_handle_exception_entry_point_offset = 0x334;
 static constexpr dart::compiler::target::word
-    AOT_Thread_top_exit_frame_info_offset = 0x3c0;
-static constexpr dart::compiler::target::word AOT_Thread_top_offset = 0x24;
+    AOT_Thread_top_exit_frame_info_offset = 0x348;
+static constexpr dart::compiler::target::word AOT_Thread_top_offset = 0x2c;
 static constexpr dart::compiler::target::word AOT_Thread_top_resource_offset =
     0x10;
 static constexpr dart::compiler::target::word
-    AOT_Thread_unboxed_runtime_arg_offset = 0x3d8;
-static constexpr dart::compiler::target::word AOT_Thread_vm_tag_offset = 0x3d4;
+    AOT_Thread_unboxed_runtime_arg_offset = 0x448;
+static constexpr dart::compiler::target::word AOT_Thread_vm_tag_offset = 0x35c;
 static constexpr dart::compiler::target::word
     AOT_Thread_write_barrier_entry_point_offset = 0xfc;
 static constexpr dart::compiler::target::word
-    AOT_Thread_write_barrier_mask_offset = 0x20;
+    AOT_Thread_write_barrier_mask_offset = 0x28;
 static constexpr dart::compiler::target::word AOT_Thread_next_task_id_offset =
-    0x410;
-static constexpr dart::compiler::target::word AOT_Thread_random_offset = 0x418;
+    0x458;
+static constexpr dart::compiler::target::word AOT_Thread_random_offset = 0x460;
 static constexpr dart::compiler::target::word
     AOT_Thread_jump_to_frame_entry_point_offset = 0x138;
 static constexpr dart::compiler::target::word AOT_Thread_tsan_utils_offset =
-    0x420;
+    0x468;
+static constexpr dart::compiler::target::word AOT_Thread_current_tag_offset =
+    0x474;
+static constexpr dart::compiler::target::word AOT_Thread_default_tag_offset =
+    0x478;
+static constexpr dart::compiler::target::word AOT_Thread_user_tag_offset =
+    0x470;
 static constexpr dart::compiler::target::word
     AOT_TsanUtils_setjmp_function_offset = 0x0;
 static constexpr dart::compiler::target::word
@@ -26698,9 +26830,9 @@ static constexpr dart::compiler::target::word AOT_Code_entry_point_offset[] = {
     0x4, 0xc, 0x8, 0x10};
 static constexpr dart::compiler::target::word
     AOT_Thread_write_barrier_wrappers_thread_offset[] = {
-        -1,    -1,    0x338, 0x33c, 0x340, 0x344, 0x348, 0x34c,
-        0x350, 0x354, 0x358, 0x35c, 0x360, 0x364, 0x368, 0x36c,
-        0x370, 0x374, 0x378, -1,    0x37c, 0x380, -1,    -1,
+        -1,    -1,    0x2c0, 0x2c4, 0x2c8, 0x2cc, 0x2d0, 0x2d4,
+        0x2d8, 0x2dc, 0x2e0, 0x2e4, 0x2e8, 0x2ec, 0x2f0, 0x2f4,
+        0x2f8, 0x2fc, 0x300, -1,    0x304, 0x308, -1,    -1,
         -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1};
 static constexpr dart::compiler::target::word AOT_AbstractType_InstanceSize =
     0x14;
@@ -26728,7 +26860,7 @@ static constexpr dart::compiler::target::word
     AOT_ExternalTypedData_InstanceSize = 0xc;
 static constexpr dart::compiler::target::word
     AOT_FfiTrampolineData_InstanceSize = 0x1c;
-static constexpr dart::compiler::target::word AOT_Field_InstanceSize = 0x34;
+static constexpr dart::compiler::target::word AOT_Field_InstanceSize = 0x38;
 static constexpr dart::compiler::target::word AOT_Finalizer_InstanceSize = 0x1c;
 static constexpr dart::compiler::target::word AOT_FinalizerEntry_InstanceSize =
     0x20;
@@ -26818,7 +26950,7 @@ static constexpr dart::compiler::target::word AOT_UnlinkedCall_InstanceSize =
     0x10;
 static constexpr dart::compiler::target::word AOT_UnwindError_InstanceSize =
     0xc;
-static constexpr dart::compiler::target::word AOT_UserTag_InstanceSize = 0x10;
+static constexpr dart::compiler::target::word AOT_UserTag_InstanceSize = 0xc;
 static constexpr dart::compiler::target::word AOT_WeakProperty_InstanceSize =
     0x10;
 static constexpr dart::compiler::target::word AOT_WeakReference_InstanceSize =

--- a/runtime/vm/constants_mips.h
+++ b/runtime/vm/constants_mips.h
@@ -604,6 +604,23 @@ struct DoubleToIntegerStubABI {
   static constexpr Register kResultReg = V0;
 };
 
+// The registers kFieldReg and kValueReg are used to pass arguments
+// from CheckedStoreIntoSharedSlowPath::EmitNativeCode to
+// CheckedStoreIntoSharedStub, and the result of the CheckedStoreIntoSharedStub
+// stub is stored in kResultReg.
+struct CheckedStoreIntoSharedStubABI {
+  static constexpr Register kFieldReg = T1;
+  static constexpr Register kValueReg = T2;
+  static constexpr Register kResultReg = V0;
+};
+
+// The register kValueReg is used to pass an argument to
+// EnsureDeeplyImmutableStub.
+struct EnsureDeeplyImmutableStubABI {
+  static constexpr Register kValueReg = A0;
+  static constexpr Register kTempReg = T1;
+};
+
 // ABI for SuspendStub (AwaitStub, AwaitWithTypeCheckStub, YieldAsyncStarStub,
 // SuspendSyncStarAtStartStub, SuspendSyncStarAtYieldStub).
 struct SuspendStubABI {

--- a/runtime/vm/instructions.h
+++ b/runtime/vm/instructions.h
@@ -17,6 +17,8 @@
 #include "vm/instructions_arm64.h"
 #elif defined(TARGET_ARCH_RISCV32) || defined(TARGET_ARCH_RISCV64)
 #include "vm/instructions_riscv.h"
+#elif defined(TARGET_ARCH_MIPS)
+#include "vm/instructions_mips.h"
 #else
 #error Unknown architecture.
 #endif

--- a/runtime/vm/instructions_mips.cc
+++ b/runtime/vm/instructions_mips.cc
@@ -1,0 +1,299 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#include "vm/globals.h"  // Needed here to get TARGET_ARCH_MIPS.
+#if defined(TARGET_ARCH_MIPS)
+
+#include "vm/instructions.h"
+#include "vm/instructions_mips.h"
+
+#include "vm/object.h"
+namespace dart {
+
+static bool IsBranchLinkScratch(Register reg) {
+  // See Assembler::BranchLink and Assembler::BranchLinkWithEquivalence
+  return FLAG_precompiled_mode ? reg == TMP : reg == CODE_REG;
+}
+
+CallPattern::CallPattern(uword pc, const Code& code)
+    : object_pool_(ObjectPool::Handle(code.GetObjectPool())),
+      target_code_pool_index_(-1) {
+  ASSERT(code.ContainsInstructionAt(pc));
+  // Last instruction: jalr RA, T9(=R25).
+  ASSERT(*(reinterpret_cast<uword*>(pc) - 2) == 0x0320f809);
+  Register reg;
+  // The end of the pattern is the instruction after the delay slot of the jalr.
+  InstructionPattern::DecodeLoadWordFromPool(pc - (3 * Instr::kInstrSize), &reg,
+                                             &target_code_pool_index_);
+  ASSERT(IsBranchLinkScratch(reg));
+}
+
+ICCallPattern::ICCallPattern(uword pc, const Code& code)
+    : object_pool_(ObjectPool::Handle(code.GetObjectPool())),
+      target_pool_index_(-1),
+      data_pool_index_(-1) {
+  ASSERT(code.ContainsInstructionAt(pc));
+  // Last instruction: jalr RA, T9(=R25).
+  ASSERT(*(reinterpret_cast<uword*>(pc) - 2) == 0x0320f809);
+  Register reg;
+  // The end of the pattern is the instruction after the delay slot of the jalr.
+  uword data_load_end = InstructionPattern::DecodeLoadWordFromPool(
+      pc - (3 * Instr::kInstrSize), &reg, &target_pool_index_);
+
+  ASSERT(IsBranchLinkScratch(reg));
+
+  InstructionPattern::DecodeLoadWordFromPool(data_load_end, &reg,
+                                             &data_pool_index_);
+
+  ASSERT(reg == ICREG);
+}
+
+NativeCallPattern::NativeCallPattern(uword pc, const Code& code)
+    : object_pool_(ObjectPool::Handle(code.GetObjectPool())),
+      end_(pc),
+      native_function_pool_index_(-1),
+      target_code_pool_index_(-1) {
+  ASSERT(code.ContainsInstructionAt(pc));
+  // Last instruction: jalr RA, T9(=R25).
+  ASSERT(*(reinterpret_cast<uword*>(end_) - 2) == 0x0320f809);
+
+  Register reg;
+  uword native_function_load_end = InstructionPattern::DecodeLoadWordFromPool(
+      end_ - 3 * Instr::kInstrSize, &reg, &target_code_pool_index_);
+  ASSERT(IsBranchLinkScratch(reg));
+  InstructionPattern::DecodeLoadWordFromPool(native_function_load_end, &reg,
+                                             &native_function_pool_index_);
+  ASSERT(reg == T5);
+}
+
+// Decodes a load sequence ending at 'end' (the last instruction of the load
+// sequence is the instruction before the one at end).  Returns a pointer to
+// the first instruction in the sequence.  Returns the register being loaded
+// and the loaded immediate value in the output parameters 'reg' and 'value'
+// respectively.
+uword InstructionPattern::DecodeLoadWordImmediate(uword end,
+                                                  Register* reg,
+                                                  intptr_t* value) {
+  // The pattern is a fixed size, but match backwards for uniformity with
+  // DecodeLoadWordFromPool.
+  uword start = end - Instr::kInstrSize;
+  Instr* instr = Instr::At(start);
+  intptr_t imm = 0;
+  ASSERT(instr->OpcodeField() == ORI);
+  imm = instr->UImmField();
+  *reg = instr->RtField();
+
+  start -= Instr::kInstrSize;
+  instr = Instr::At(start);
+  ASSERT(instr->OpcodeField() == LUI);
+  ASSERT(instr->RtField() == *reg);
+  imm |= (instr->UImmField() << 16);
+  *value = imm;
+  return start;
+}
+
+void InstructionPattern::EncodeLoadWordImmediate(uword end,
+                                                 Register reg,
+                                                 intptr_t value) {
+  uint16_t low16 = value & 0xffff;
+  uint16_t high16 = (value >> 16) & 0xffff;
+
+  // lui reg, #imm_hi
+  uint32_t lui_instr =
+      LUI << kOpcodeShift | R0 << kRsShift | reg << kRtShift | high16;
+
+  // ori reg, reg, #imm_lo
+  uint32_t ori_instr =
+      ORI << kOpcodeShift | reg << kRsShift | reg << kRtShift | low16;
+
+  uint32_t* cursor = reinterpret_cast<uint32_t*>(end);
+  *(--cursor) = ori_instr;
+  *(--cursor) = lui_instr;
+
+#if defined(DEBUG)
+  Register decoded_reg;
+  intptr_t decoded_value;
+  DecodeLoadWordImmediate(end, &decoded_reg, &decoded_value);
+  ASSERT(reg == decoded_reg);
+  ASSERT(value == decoded_value);
+#endif
+}
+
+// Decodes a load sequence ending at 'end' (the last instruction of the load
+// sequence is the instruction before the one at end).  Returns a pointer to
+// the first instruction in the sequence.  Returns the register being loaded
+// and the index in the pool being read from in the output parameters 'reg'
+// and 'index' respectively.
+uword InstructionPattern::DecodeLoadWordFromPool(uword end,
+                                                 Register* reg,
+                                                 intptr_t* index) {
+  uword start = end - Instr::kInstrSize;
+  Instr* instr = Instr::At(start);
+  intptr_t offset = 0;
+  if ((instr->OpcodeField() == LW) && (instr->RsField() == PP)) {
+    offset = instr->SImmField();
+    *reg = instr->RtField();
+  } else {
+    ASSERT(instr->OpcodeField() == LW);
+    offset = instr->SImmField();
+    *reg = instr->RtField();
+
+    start -= Instr::kInstrSize;
+    instr = Instr::At(start);
+    ASSERT(instr->OpcodeField() == SPECIAL);
+    ASSERT(instr->FunctionField() == ADDU);
+    ASSERT(instr->RdField() == *reg);
+    ASSERT(instr->RsField() == *reg);
+    ASSERT(instr->RtField() == PP);
+
+    start -= Instr::kInstrSize;
+    instr = Instr::At(start);
+    ASSERT(instr->OpcodeField() == LUI);
+    ASSERT(instr->RtField() == *reg);
+    // Offset is signed, so add the upper 16 bits.
+    offset += (instr->UImmField() << 16);
+  }
+  *index = ObjectPool::IndexFromOffset(offset);
+  return start;
+}
+
+bool DecodeLoadObjectFromPoolOrThread(uword pc, const Code& code, Object* obj) {
+  ASSERT(code.ContainsInstructionAt(pc));
+
+  Instr* instr = Instr::At(pc);
+  if ((instr->OpcodeField() == LW)) {
+    intptr_t offset = instr->SImmField();
+    if (instr->RsField() == PP) {
+      intptr_t index = ObjectPool::IndexFromOffset(offset);
+      return ObjectAtPoolIndex(code, index, obj);
+    } else if (instr->RsField() == THR) {
+      return Thread::ObjectAtOffset(offset, obj);
+    }
+  }
+  return false;
+}
+
+CodePtr CallPattern::TargetCode() const {
+  return static_cast<CodePtr>(object_pool_.ObjectAt<std::memory_order_acquire>(
+      target_code_pool_index_));
+}
+
+void CallPattern::SetTargetCode(const Code& target) const {
+  object_pool_.SetObjectAt<std::memory_order_release>(target_code_pool_index_,
+                                                      target);
+}
+
+ObjectPtr ICCallPattern::Data() const {
+  return object_pool_.ObjectAt<std::memory_order_acquire>(data_pool_index_);
+}
+
+void ICCallPattern::SetData(const Object& data) const {
+  ASSERT(data.IsArray() || data.IsICData() || data.IsMegamorphicCache());
+  object_pool_.SetObjectAt<std::memory_order_release>(data_pool_index_, data);
+}
+
+CodePtr ICCallPattern::TargetCode() const {
+  return static_cast<CodePtr>(
+      object_pool_.ObjectAt<std::memory_order_acquire>(target_pool_index_));
+}
+
+void ICCallPattern::SetTargetCode(const Code& target_code) const {
+  object_pool_.SetObjectAt<std::memory_order_release>(target_pool_index_,
+                                                      target_code);
+}
+
+CodePtr NativeCallPattern::target() const {
+  return static_cast<CodePtr>(object_pool_.ObjectAt<std::memory_order_acquire>(
+      target_code_pool_index_));
+}
+
+void NativeCallPattern::set_target(const Code& target) const {
+  object_pool_.SetObjectAt<std::memory_order_release>(target_code_pool_index_,
+                                                      target);
+  // No need to flush the instruction cache, since the code is not modified.
+}
+
+NativeFunction NativeCallPattern::native_function() const {
+  return reinterpret_cast<NativeFunction>(
+      object_pool_.RawValueAt(native_function_pool_index_));
+}
+
+void NativeCallPattern::set_native_function(NativeFunction func) const {
+  object_pool_.SetRawValueAt<std::memory_order_relaxed>(
+      native_function_pool_index_, reinterpret_cast<uword>(func));
+}
+
+SwitchableCallPatternBase::SwitchableCallPatternBase(
+    const ObjectPool& object_pool)
+    : object_pool_(object_pool), data_pool_index_(-1), target_pool_index_(-1) {}
+
+ObjectPtr SwitchableCallPatternBase::data() const {
+  return object_pool_.ObjectAt<std::memory_order_acquire>(data_pool_index_);
+}
+
+void SwitchableCallPatternBase::SetDataRelease(const Object& data) const {
+  ASSERT(!Object::Handle(object_pool_.ObjectAt<std::memory_order_relaxed>(
+                             data_pool_index_))
+              .IsCode());
+  object_pool_.SetObjectAt<std::memory_order_release>(data_pool_index_, data);
+}
+
+SwitchableCallPattern::SwitchableCallPattern(uword pc, const Code& code)
+    : SwitchableCallPatternBase(ObjectPool::Handle(code.GetObjectPool())) {
+  ASSERT(code.ContainsInstructionAt(pc));
+  // Last instruction: jalr t9.
+  ASSERT(*(reinterpret_cast<uword*>(pc) - 1) == 0);  // Delay slot.
+  ASSERT(*(reinterpret_cast<uword*>(pc) - 2) == 0x0320f809);
+
+  Register reg;
+  uword data_load_end = InstructionPattern::DecodeLoadWordFromPool(
+      pc - 2 * Instr::kInstrSize, &reg, &data_pool_index_);
+  ASSERT(reg == S5);
+  InstructionPattern::DecodeLoadWordFromPool(data_load_end, &reg,
+                                             &target_pool_index_);
+  ASSERT(reg == T9);
+}
+
+ObjectPtr SwitchableCallPattern::target() const {
+  return object_pool_.ObjectAt<std::memory_order_acquire>(target_pool_index_);
+}
+
+void SwitchableCallPattern::SetTargetRelease(const Code& target) const {
+  ASSERT(Object::Handle(object_pool_.ObjectAt<std::memory_order_relaxed>(
+                            target_pool_index_))
+             .IsCode());
+  object_pool_.SetObjectAt<std::memory_order_release>(target_pool_index_,
+                                                      target);
+}
+
+BareSwitchableCallPattern::BareSwitchableCallPattern(uword pc)
+    : SwitchableCallPatternBase(ObjectPool::Handle(
+          IsolateGroup::Current()->object_store()->global_object_pool())) {
+  // Last instruction: jalr t9.
+  ASSERT(*(reinterpret_cast<uword*>(pc) - 1) == 0);  // Delay slot.
+  ASSERT(*(reinterpret_cast<uword*>(pc) - 2) == 0x0320f809);
+
+  Register reg;
+  uword data_load_end = InstructionPattern::DecodeLoadWordFromPool(
+      pc - 2 * Instr::kInstrSize, &reg, &data_pool_index_);
+  ASSERT(reg == S5);
+  InstructionPattern::DecodeLoadWordFromPool(data_load_end, &reg,
+                                             &target_pool_index_);
+  ASSERT(reg == T9);
+}
+
+uword BareSwitchableCallPattern::target_entry() const {
+  return object_pool_.RawValueAt<std::memory_order_relaxed>(target_pool_index_);
+}
+
+void BareSwitchableCallPattern::SetTargetRelease(const Code& target) const {
+  ASSERT(object_pool_.TypeAt(target_pool_index_) ==
+         ObjectPool::EntryType::kImmediate);
+  object_pool_.SetRawValueAt<std::memory_order_release>(
+      target_pool_index_, target.MonomorphicEntryPoint());
+}
+
+}  // namespace dart
+
+#endif  // defined TARGET_ARCH_MIPS

--- a/runtime/vm/instructions_mips.h
+++ b/runtime/vm/instructions_mips.h
@@ -1,0 +1,218 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+// Classes that describe assembly patterns as used by inline caches.
+
+#ifndef RUNTIME_VM_INSTRUCTIONS_MIPS_H_
+#define RUNTIME_VM_INSTRUCTIONS_MIPS_H_
+
+#ifndef RUNTIME_VM_INSTRUCTIONS_H_
+#error Do not include instructions_mips.h directly; use instructions.h instead.
+#endif
+
+#include "vm/allocation.h"
+#include "vm/constants.h"
+#include "vm/native_function.h"
+#include "vm/tagged_pointer.h"
+
+#if !defined(DART_PRECOMPILED_RUNTIME)
+#include "vm/compiler/assembler/assembler.h"
+#endif  // !defined(DART_PRECOMPILED_RUNTIME)
+
+namespace dart {
+
+class ICData;
+class Code;
+class Object;
+class ObjectPool;
+class UntaggedCode;
+
+class InstructionPattern : public AllStatic {
+ public:
+  // Decodes a load sequence ending at 'end' (the last instruction of the
+  // load sequence is the instruction before the one at end).  Returns the
+  // address of the first instruction in the sequence.  Returns the register
+  // being loaded and the loaded immediate value in the output parameters
+  // 'reg' and 'value' respectively.
+  static uword DecodeLoadWordImmediate(uword end,
+                                       Register* reg,
+                                       intptr_t* value);
+
+  // Encodes a load immediate sequence ending at 'end' (the last instruction of
+  // the load sequence is the instruction before the one at end).
+  //
+  // Supports only a subset of [DecodeLoadWordImmediate], namely:
+  //   lui reg, #imm_hi
+  //   ori reg, reg, #imm_lo
+  static void EncodeLoadWordImmediate(uword end, Register reg, intptr_t value);
+
+  // Decodes a load sequence ending at 'end' (the last instruction of the
+  // load sequence is the instruction before the one at end).  Returns the
+  // address of the first instruction in the sequence.  Returns the register
+  // being loaded and the index in the pool being read from in the output
+  // parameters 'reg' and 'index' respectively.
+  static uword DecodeLoadWordFromPool(uword end,
+                                      Register* reg,
+                                      intptr_t* index);
+};
+
+class CallPattern : public ValueObject {
+ public:
+  CallPattern(uword pc, const Code& code);
+
+  CodePtr TargetCode() const;
+  void SetTargetCode(const Code& target) const;
+
+ private:
+  const ObjectPool& object_pool_;
+  intptr_t target_code_pool_index_;
+
+  DISALLOW_COPY_AND_ASSIGN(CallPattern);
+};
+
+class ICCallPattern : public ValueObject {
+ public:
+  ICCallPattern(uword pc, const Code& code);
+
+  ObjectPtr Data() const;
+  void SetData(const Object& data) const;
+
+  CodePtr TargetCode() const;
+  void SetTargetCode(const Code& code) const;
+
+ private:
+  const ObjectPool& object_pool_;
+
+  intptr_t target_pool_index_;
+  intptr_t data_pool_index_;
+
+  DISALLOW_COPY_AND_ASSIGN(ICCallPattern);
+};
+
+class NativeCallPattern : public ValueObject {
+ public:
+  NativeCallPattern(uword pc, const Code& code);
+
+  CodePtr target() const;
+  void set_target(const Code& target) const;
+
+  NativeFunction native_function() const;
+  void set_native_function(NativeFunction target) const;
+
+ private:
+  const ObjectPool& object_pool_;
+
+  uword end_;
+  intptr_t native_function_pool_index_;
+  intptr_t target_code_pool_index_;
+
+  DISALLOW_COPY_AND_ASSIGN(NativeCallPattern);
+};
+
+// Instance call that can switch between a direct monomorphic call, an IC call,
+// and a megamorphic call.
+//   load guarded cid            load ICData             load MegamorphicCache
+//   load monomorphic target <-> load ICLookup stub  ->  load MMLookup stub
+//   call target.entry           call stub.entry         call stub.entry
+class SwitchableCallPatternBase : public ValueObject {
+ public:
+  explicit SwitchableCallPatternBase(const ObjectPool& object_pool);
+
+  ObjectPtr data() const;
+  void SetDataRelease(const Object& data) const;
+
+ protected:
+  const ObjectPool& object_pool_;
+  intptr_t data_pool_index_;
+  intptr_t target_pool_index_;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(SwitchableCallPatternBase);
+};
+
+// See [SwitchableCallBase] for a switchable calls in general.
+//
+// The target slot is always a [Code] object: Either the code of the
+// monomorphic function or a stub code.
+class SwitchableCallPattern : public SwitchableCallPatternBase {
+ public:
+  SwitchableCallPattern(uword pc, const Code& code);
+
+  ObjectPtr target() const;
+  void SetTargetRelease(const Code& target) const;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(SwitchableCallPattern);
+};
+
+// See [SwitchableCallBase] for a switchable calls in general.
+//
+// The target slot is always a direct entrypoint address: Either the entry point
+// of the monomorphic function or a stub entry point.
+class BareSwitchableCallPattern : public SwitchableCallPatternBase {
+ public:
+  explicit BareSwitchableCallPattern(uword pc);
+
+  uword target_entry() const;
+  void SetTargetRelease(const Code& target) const;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(BareSwitchableCallPattern);
+};
+
+class PcRelativePatternBase : public ValueObject {
+ public:
+  // 16 bit signed integer which will get multiplied by 4.
+  static constexpr intptr_t kLowerCallingRange = -(1 << 17) + Instr::kInstrSize;
+  static constexpr intptr_t kUpperCallingRange = (1 << 17) - Instr::kInstrSize;
+
+  explicit PcRelativePatternBase(uword pc) : pc_(pc) {}
+
+  static constexpr int kLengthInBytes = 2 * Instr::kInstrSize;
+
+  int32_t distance() {
+    UNREACHABLE();
+    return 0;
+  }
+
+  void set_distance(int32_t distance) { UNREACHABLE(); }
+
+ protected:
+  uword pc_;
+};
+
+class PcRelativeCallPattern : public PcRelativePatternBase {
+ public:
+  explicit PcRelativeCallPattern(uword pc) : PcRelativePatternBase(pc) {}
+
+  bool IsValid() const;
+};
+
+class PcRelativeTailCallPattern : public PcRelativePatternBase {
+ public:
+  explicit PcRelativeTailCallPattern(uword pc) : PcRelativePatternBase(pc) {}
+
+  bool IsValid() const;
+};
+
+class PcRelativeTrampolineJumpPattern : public ValueObject {
+ public:
+  explicit PcRelativeTrampolineJumpPattern(uword pattern_start)
+      : pattern_start_(pattern_start) {
+    USE(pattern_start_);
+  }
+
+  static constexpr int kLengthInBytes = 9 * Instr::kInstrSize;
+
+  void Initialize();
+
+  int32_t distance();
+  void set_distance(int32_t distance);
+  bool IsValid() const;
+
+  uword pattern_start_;
+};
+
+}  // namespace dart
+
+#endif  // RUNTIME_VM_INSTRUCTIONS_MIPS_H_

--- a/runtime/vm/vm_sources.gni
+++ b/runtime/vm/vm_sources.gni
@@ -142,6 +142,8 @@ vm_sources = [
   "instructions_arm64.h",
   "instructions_ia32.cc",
   "instructions_ia32.h",
+  "instructions_mips.cc",
+  "instructions_mips.h",
   "instructions_riscv.cc",
   "instructions_riscv.h",
   "instructions_x64.cc",


### PR DESCRIPTION
This PR introduces a set of MIPS-specific adjustments to align with the current version of the project.

Key changes include:

- Updated code_patcher_mips.cc.
- Modified the CallRuntime function.
- Added new helper functions:
  - StoreStoreFence
  - TsanFuncEntry
  - TsanFuncExit
- Introduced new ABI-related structures:
  - CheckedStoreIntoSharedStubABI
  - EnsureDeeplyImmutableStubABI

Additionally, the following branch-link related implementations were added:
- BranchLink
- BranchLinkPatchable
- BranchLinkWithEquivalence

A new file has been added which implements instruction decoding and call pattern handling for MIPS, including:
- CallPattern, ICCallPattern, NativeCallPattern
- Switchable and BareSwitchable call patterns
- InstructionPattern helpers for decoding/encoding load sequences
- Utilities for working with object pools and native calls