### PR TITLE
[mips] Add codegen for memory copy, boxing/unboxing, doubles, comparisons and boolean ops

### DIFF
--- a/runtime/vm/compiler/backend/il_mips.cc
+++ b/runtime/vm/compiler/backend/il_mips.cc
@@ -985,6 +985,20 @@ LocationSummary* StrictCompareInstr::MakeLocationSummary(Zone* zone,
   return locs;
 }
 
+LocationSummary* BooleanNegateInstr::MakeLocationSummary(Zone* zone,
+                                                         bool opt) const {
+  return LocationSummary::Make(zone, 1, Location::RequiresRegister(),
+                               LocationSummary::kNoCall);
+}
+
+void BooleanNegateInstr::EmitNativeCode(FlowGraphCompiler* compiler) {
+  Register value = locs()->in(0).reg();
+  Register result = locs()->out(0).reg();
+
+  __ xori(result, value,
+      compiler::Immediate(compiler::target::ObjectAlignment::kBoolValueMask));
+}
+
 }  // namespace dart
 
 #endif  // defined TARGET_ARCH_MIPS

--- a/runtime/vm/compiler/backend/il_mips.cc
+++ b/runtime/vm/compiler/backend/il_mips.cc
@@ -538,6 +538,113 @@ void UnboxInstr::EmitLoadInt64FromBoxOrSmi(FlowGraphCompiler* compiler) {
   __ Bind(&done);
 }
 
+LocationSummary* BoxInteger32Instr::MakeLocationSummary(Zone* zone,
+                                                        bool opt) const {
+  ASSERT((from_representation() == kUnboxedInt32) ||
+         (from_representation() == kUnboxedUint32));
+  const intptr_t kNumInputs = 1;
+  const intptr_t kNumTemps = 1;
+  LocationSummary* summary = new (zone) LocationSummary(
+      zone, kNumInputs, kNumTemps, LocationSummary::kCallOnSlowPath);
+  summary->set_in(0, Location::RequiresRegister());
+  summary->set_temp(0, Location::RequiresRegister());
+  summary->set_out(0, Location::RequiresRegister());
+  return summary;
+}
+
+void BoxInteger32Instr::EmitNativeCode(FlowGraphCompiler* compiler) {
+  Register value = locs()->in(0).reg();
+  Register out = locs()->out(0).reg();
+  ASSERT(value != out);
+
+  __ SmiTag(out, value);
+  if (!ValueFitsSmi()) {
+    Register temp = locs()->temp(0).reg();
+    compiler::Label done;
+    if (from_representation() == kUnboxedInt32) {
+      __ SmiUntag(CMPRES1, out);
+      __ BranchEqual(CMPRES1, value, &done);
+    } else {
+      ASSERT(from_representation() == kUnboxedUint32);
+      __ AndImmediate(CMPRES1, value, 0xC0000000);
+      __ BranchEqual(CMPRES1, ZR, &done);
+    }
+    BoxAllocationSlowPath::Allocate(compiler, this, compiler->mint_class(), out,
+                                    temp);
+    Register hi;
+    if (from_representation() == kUnboxedInt32) {
+      hi = temp;
+      __ sra(hi, value, kBitsPerWord - 1);
+    } else {
+      ASSERT(from_representation() == kUnboxedUint32);
+      hi = ZR;
+    }
+    __ StoreToOffset(value, out, Mint::value_offset() - kHeapObjectTag);
+    __ StoreToOffset(hi, out,
+                     Mint::value_offset() - kHeapObjectTag + kWordSize);
+    __ Bind(&done);
+  }
+}
+
+LocationSummary* UnboxInteger32Instr::MakeLocationSummary(Zone* zone,
+                                                          bool opt) const {
+  ASSERT((representation() == kUnboxedInt32) ||
+         (representation() == kUnboxedUint32));
+  const intptr_t kNumInputs = 1;
+  const intptr_t kNumTemps = 0;
+  LocationSummary* summary = new (zone)
+      LocationSummary(zone, kNumInputs, kNumTemps, LocationSummary::kNoCall);
+  summary->set_in(0, Location::RequiresRegister());
+  summary->set_out(0, Location::RequiresRegister());
+  return summary;
+}
+
+static void LoadInt32FromMint(FlowGraphCompiler* compiler,
+                              Register mint,
+                              Register result,
+                              compiler::Label* deopt) {
+  __ LoadFieldFromOffset(result, mint, Mint::value_offset());
+  if (deopt != NULL) {
+    __ LoadFieldFromOffset(CMPRES1, mint, Mint::value_offset() + kWordSize);
+    __ sra(CMPRES2, result, kBitsPerWord - 1);
+    __ BranchNotEqual(CMPRES1, CMPRES2, deopt);
+  }
+}
+
+void UnboxInteger32Instr::EmitNativeCode(FlowGraphCompiler* compiler) {
+  const intptr_t value_cid = value()->Type()->ToCid();
+  const Register value = locs()->in(0).reg();
+  const Register out = locs()->out(0).reg();
+  compiler::Label* deopt =
+      CanDeoptimize()
+          ? compiler->AddDeoptStub(GetDeoptId(), ICData::kDeoptUnboxInteger)
+          : NULL;
+  compiler::Label* out_of_range = !is_truncating() ? deopt : NULL;
+  ASSERT(value != out);
+
+  if (value_cid == kSmiCid) {
+    __ SmiUntag(out, value);
+  } else if (value_cid == kMintCid) {
+    LoadInt32FromMint(compiler, value, out, out_of_range);
+  } else if (!CanDeoptimize()) {
+    compiler::Label done;
+    __ SmiUntag(out, value);
+    __ AndImmediate(CMPRES1, value, kSmiTagMask);
+    __ beq(CMPRES1, ZR, &done);
+    LoadInt32FromMint(compiler, value, out, NULL);
+    __ Bind(&done);
+  } else {
+    compiler::Label done;
+    __ SmiUntag(out, value);
+    __ AndImmediate(CMPRES1, value, kSmiTagMask);
+    __ beq(CMPRES1, ZR, &done);
+    __ LoadClassId(CMPRES1, value);
+    __ BranchNotEqual(CMPRES1, compiler::Immediate(kMintCid), deopt);
+    LoadInt32FromMint(compiler, value, out, out_of_range);
+    __ Bind(&done);
+  }
+}
+
 }  // namespace dart
 
 #endif  // defined TARGET_ARCH_MIPS

--- a/runtime/vm/compiler/backend/il_mips.cc
+++ b/runtime/vm/compiler/backend/il_mips.cc
@@ -438,6 +438,106 @@ void FfiCallInstr::EmitNativeCode(FlowGraphCompiler* compiler) {
   }
 }
 
+LocationSummary* UnboxInstr::MakeLocationSummary(Zone* zone, bool opt) const {
+  ASSERT(BoxCid() != kSmiCid);
+  const bool needs_temp = CanDeoptimize();
+  const intptr_t kNumInputs = 1;
+  const intptr_t kNumTemps = needs_temp ? 1 : 0;
+  LocationSummary* summary = new (zone)
+      LocationSummary(zone, kNumInputs, kNumTemps, LocationSummary::kNoCall);
+  summary->set_in(0, Location::RequiresRegister());
+  if (needs_temp) {
+    summary->set_temp(0, Location::RequiresRegister());
+  }
+  if (representation() == kUnboxedInt64) {
+    summary->set_out(0, Location::Pair(Location::RequiresRegister(),
+                                       Location::RequiresRegister()));
+  } else if (representation() == kUnboxedInt32) {
+    summary->set_out(0, Location::RequiresRegister());
+  } else {
+    summary->set_out(0, Location::RequiresFpuRegister());
+  }
+  return summary;
+}
+
+void UnboxInstr::EmitLoadFromBox(FlowGraphCompiler* compiler) {
+  const Register box = locs()->in(0).reg();
+
+  switch (representation()) {
+    case kUnboxedInt64: {
+      PairLocation* result = locs()->out(0).AsPairLocation();
+      ASSERT(result->At(0).reg() != box);
+      __ LoadFromOffset(result->At(0).reg(), box,
+                        ValueOffset() - kHeapObjectTag);
+      __ LoadFromOffset(result->At(1).reg(), box,
+                        ValueOffset() - kHeapObjectTag + compiler::target::kWordSize);
+      break;
+    }
+    case kUnboxedDouble: {
+      const DRegister result = locs()->out(0).fpu_reg();
+      __ LoadDFromOffset(result, box, Double::value_offset() - kHeapObjectTag);
+      break;
+    }
+    case kUnboxedFloat: {
+      const DRegister result = locs()->out(0).fpu_reg();
+      __ LoadDFromOffset(result, box, ValueOffset() - kHeapObjectTag);
+      __ cvtsd(EvenFRegisterOf(result), result);
+      break;
+    }
+    case kUnboxedFloat32x4:
+    case kUnboxedFloat64x2:
+    case kUnboxedInt32x4: {
+      UNIMPLEMENTED();
+      break;
+    }
+    default:
+      UNREACHABLE();
+      break;
+  }
+}
+
+void UnboxInstr::EmitSmiConversion(FlowGraphCompiler* compiler) {
+  const Register box = locs()->in(0).reg();
+
+  switch (representation()) {
+    case kUnboxedInt64: {
+      PairLocation* result = locs()->out(0).AsPairLocation();
+      __ SmiUntag(result->At(0).reg(), box);
+      __ sra(result->At(1).reg(), result->At(0).reg(), 31);
+      break;
+    }
+    case kUnboxedDouble: {
+      const DRegister result = locs()->out(0).fpu_reg();
+      __ SmiUntag(TMP, box);
+      __ mtc1(TMP, STMP1);
+      __ cvtdw(result, STMP1);
+      break;
+    }
+    default:
+      UNREACHABLE();
+      break;
+  }
+}
+
+void UnboxInstr::EmitLoadInt32FromBoxOrSmi(FlowGraphCompiler* compiler) {
+  const Register value = locs()->in(0).reg();
+  const Register result = locs()->out(0).reg();
+  __ LoadInt32FromBoxOrSmi(result, value);
+}
+
+void UnboxInstr::EmitLoadInt64FromBoxOrSmi(FlowGraphCompiler* compiler) {
+  const Register box = locs()->in(0).reg();
+  PairLocation* result = locs()->out(0).AsPairLocation();
+  ASSERT(result->At(0).reg() != box);
+  ASSERT(result->At(1).reg() != box);
+  compiler::Label done;
+  __ sra(result->At(1).reg(), box, 31);
+  __ SmiUntag(result->At(0).reg(), box);
+  __ BranchIfSmi(box, &done);
+  EmitLoadFromBox(compiler);
+  __ Bind(&done);
+}
+
 }  // namespace dart
 
 #endif  // defined TARGET_ARCH_MIPS

--- a/runtime/vm/compiler/backend/il_mips.cc
+++ b/runtime/vm/compiler/backend/il_mips.cc
@@ -271,6 +271,87 @@ void MemoryCopyInstr::EmitComputeStartPointer(FlowGraphCompiler* compiler,
   __ AddImmediate(payload_reg, offset);
 }
 
+LocationSummary* EqualityCompareInstr::MakeLocationSummary(Zone* zone,
+                                                           bool opt) const {
+  const intptr_t kNumInputs = 2;
+  const intptr_t kNumTemps = 0;
+  if (is_null_aware()) {
+    LocationSummary* locs = new (zone)
+        LocationSummary(zone, kNumInputs, kNumTemps, LocationSummary::kNoCall);
+    locs->set_in(0, Location::RequiresRegister());
+    locs->set_in(1, Location::RequiresRegister());
+    locs->set_out(0, Location::RequiresRegister());
+    return locs;
+  }
+  if (operation_cid() == kMintCid) {
+    LocationSummary* locs = new (zone)
+        LocationSummary(zone, kNumInputs, kNumTemps, LocationSummary::kNoCall);
+    locs->set_in(0, Location::Pair(Location::RequiresRegister(),
+                                   Location::RequiresRegister()));
+    locs->set_in(1, Location::Pair(Location::RequiresRegister(),
+                                   Location::RequiresRegister()));
+    locs->set_out(0, Location::RequiresRegister());
+    return locs;
+  }
+  if (operation_cid() == kDoubleCid) {
+    LocationSummary* locs = new (zone)
+        LocationSummary(zone, kNumInputs, kNumTemps, LocationSummary::kNoCall);
+    locs->set_in(0, Location::RequiresFpuRegister());
+    locs->set_in(1, Location::RequiresFpuRegister());
+    locs->set_out(0, Location::RequiresRegister());
+    return locs;
+  }
+  if (operation_cid() == kSmiCid || operation_cid() == kMintCid ||
+      operation_cid() == kIntegerCid) {
+    LocationSummary* locs = new (zone)
+        LocationSummary(zone, kNumInputs, kNumTemps, LocationSummary::kNoCall);
+    if (is_null_aware()) {
+      locs->set_in(0, Location::RequiresRegister());
+      locs->set_in(1, Location::RequiresRegister());
+    } else {
+      locs->set_in(0, LocationRegisterOrConstant(left()));
+      // Only one input can be a constant operand. The case of two constant
+      // operands should be handled by constant propagation.
+      // Only right can be a stack slot.
+      locs->set_in(1, locs->in(0).IsConstant()
+                          ? Location::RequiresRegister()
+                          : LocationRegisterOrConstant(right()));
+    }
+    locs->set_out(0, Location::RequiresRegister());
+    return locs;
+  }
+  UNREACHABLE();
+  return nullptr;
+}
+
+Condition EqualityCompareInstr::EmitConditionCode(
+    FlowGraphCompiler* compiler,
+    BranchLabels labels) {
+  if (is_null_aware()) {
+    ASSERT(operation_cid() == kMintCid);
+    return EmitNullAwareInt64ComparisonOp(compiler, locs(), kind(), labels);
+  }
+  if (operation_cid() == kSmiCid) {
+    return EmitSmiComparisonOp(compiler, *locs(), kind());
+  } else if (operation_cid() == kIntegerCid) {
+    return EmitWordComparisonOp(compiler, locs(), kind());
+  } else if (operation_cid() == kMintCid) {
+    return EmitUnboxedMintEqualityOp(compiler, *locs(), kind(), labels);
+  } else {
+    ASSERT(operation_cid() == kDoubleCid);
+    return EmitDoubleComparisonOp(compiler, *locs(), kind(), labels);
+  }
+}
+
+Condition StrictCompareInstr::EmitComparisonCodeRegConstant(
+    FlowGraphCompiler* compiler,
+    BranchLabels labels,
+    Register reg,
+    const Object& obj) {
+  return compiler->EmitEqualityRegConstCompare(reg, obj, needs_number_check(),
+                                                source(), deopt_id());
+}
+
 #define R(r) (1 << r)
 
 LocationSummary* FfiCallInstr::MakeLocationSummary(Zone* zone,
@@ -855,6 +936,53 @@ LocationSummary* SimdOpInstr::MakeLocationSummary(Zone* zone, bool opt) const {
 
 void SimdOpInstr::EmitNativeCode(FlowGraphCompiler* compiler) {
   UNIMPLEMENTED();
+}
+
+LocationSummary* FloatCompareInstr::MakeLocationSummary(Zone* zone,
+                                                        bool opt) const {
+  UNREACHABLE();
+  return NULL;
+}
+
+void FloatCompareInstr::EmitNativeCode(FlowGraphCompiler* compiler) {
+  UNREACHABLE();
+}
+
+LocationSummary* StrictCompareInstr::MakeLocationSummary(Zone* zone,
+                                                         bool opt) const {
+  const intptr_t kNumInputs = 2;
+  const intptr_t kNumTemps = 0;
+  if (needs_number_check()) {
+    LocationSummary* locs = new (zone)
+        LocationSummary(zone, kNumInputs, kNumTemps, LocationSummary::kCall);
+    locs->set_in(0, Location::RegisterLocation(A0));
+    locs->set_in(1, Location::RegisterLocation(A1));
+    locs->set_out(0, Location::RegisterLocation(A0));
+    return locs;
+  }
+  LocationSummary* locs = new (zone)
+      LocationSummary(zone, kNumInputs, kNumTemps, LocationSummary::kNoCall);
+  // If a constant has more than one use, make sure it is loaded in register
+  // so that multiple immediate loads can be avoided.
+  ConstantInstr* constant = left()->definition()->AsConstant();
+  if ((constant != nullptr) && !left()->IsSingleUse()) {
+    locs->set_in(0, Location::RequiresRegister());
+  } else {
+    locs->set_in(0, LocationRegisterOrConstant(left()));
+  }
+
+  constant = right()->definition()->AsConstant();
+  if ((constant != nullptr) && !right()->IsSingleUse()) {
+    locs->set_in(1, Location::RequiresRegister());
+  } else {
+    // Only one of the inputs can be a constant. Choose register if the first
+    // one is a constant.
+    locs->set_in(1, locs->in(0).IsConstant()
+                        ? Location::RequiresRegister()
+                        : LocationRegisterOrConstant(right()));
+  }
+  locs->set_out(0, Location::RequiresRegister());
+  return locs;
 }
 
 }  // namespace dart

--- a/runtime/vm/compiler/backend/il_mips.cc
+++ b/runtime/vm/compiler/backend/il_mips.cc
@@ -45,6 +45,97 @@ void MemoryCopyInstr::PrepareLengthRegForLoop(FlowGraphCompiler* compiler,
   __ BranchEqual(length_reg, ZR, done);
 }
 
+// Copies [count] bytes from the memory region pointed to by [dest_reg] to the
+// memory region pointed to by [src_reg]. If [reversed] is true, then [dest_reg]
+// and [src_reg] are assumed to point at the end of the respective region.
+static void CopyBytes(FlowGraphCompiler* compiler,
+                      Register dest_reg,
+                      Register src_reg,
+                      intptr_t count,
+                      bool reversed,
+                      Register tmp) {
+  ASSERT(Utils::IsPowerOfTwo(count));
+
+  ASSERT(dest_reg != TMP);
+  ASSERT(src_reg != TMP);
+
+  if (count == 4 * compiler::target::kWordSize) {
+    auto const sz = OperandSizeFor(compiler::target::kWordSize);
+    const intptr_t offset = (reversed ? -1 : 1) * (compiler::target::kWordSize);
+    const intptr_t initial = reversed ? offset : 0;
+    __ LoadFromOffset(TMP, src_reg, initial, sz);
+    __ LoadFromOffset(tmp, src_reg, initial + offset, sz);
+    __ StoreToOffset(TMP, dest_reg, initial, sz);
+    __ StoreToOffset(tmp, dest_reg, initial + offset, sz);
+    __ LoadFromOffset(TMP, src_reg, initial + 2 * offset, sz);
+    __ LoadFromOffset(tmp, src_reg, initial + 3 * offset, sz);
+    __ StoreToOffset(TMP, dest_reg, initial + 2 * offset, sz);
+    __ StoreToOffset(tmp, dest_reg, initial + 3 * offset, sz);
+    __ AddImmediate(src_reg, src_reg, 4 * offset);
+    __ AddImmediate(dest_reg, dest_reg, 4 * offset);
+    return;
+  }
+
+  if (count == 2 * (compiler::target::kWordSize)) {
+    auto const sz = OperandSizeFor(compiler::target::kWordSize);
+    const intptr_t offset = (reversed ? -1 : 1) * (compiler::target::kWordSize);
+    const intptr_t initial = reversed ? offset : 0;
+    __ LoadFromOffset(TMP, src_reg, initial, sz);
+    __ LoadFromOffset(tmp, src_reg, initial + offset, sz);
+    __ StoreToOffset(TMP, dest_reg, initial, sz);
+    __ StoreToOffset(tmp, dest_reg, initial + offset, sz);
+    __ AddImmediate(src_reg, src_reg, 2 * offset);
+    __ AddImmediate(dest_reg, dest_reg, 2 * offset);
+    return;
+  }
+
+  auto const sz = OperandSizeFor(count);
+  const intptr_t offset = (reversed ? -1 : 1) * count;
+  const intptr_t initial = reversed ? offset : 0;
+  __ LoadFromOffset(TMP, src_reg, initial, sz);
+  __ StoreToOffset(TMP, dest_reg, initial, sz);
+  __ AddImmediate(src_reg, src_reg, offset);
+  __ AddImmediate(dest_reg, dest_reg, offset);
+}
+
+static void CopyUpToWordMultiple(FlowGraphCompiler* compiler,
+                                 Register dest_reg,
+                                 Register src_reg,
+                                 Register length_reg,
+                                 intptr_t element_size,
+                                 bool unboxed_inputs,
+                                 bool reversed,
+                                 compiler::Label* done,
+                                 Register temp) {
+  ASSERT(Utils::IsPowerOfTwo(element_size));
+  if (element_size >= compiler::target::kWordSize) return;
+
+  const intptr_t element_shift = Utils::ShiftForPowerOfTwo(element_size);
+  const intptr_t base_shift =
+      (unboxed_inputs ? 0 : kSmiTagShift) - element_shift;
+  intptr_t tested_bits = 0;
+
+  __ Comment("Copying until region is a multiple of word size");
+
+  for (intptr_t bit = compiler::target::kWordSizeLog2 - 1; bit >= element_shift;
+       bit--) {
+    const intptr_t bytes = 1 << bit;
+    const intptr_t tested_bit = bit + base_shift;
+    tested_bits |= (1 << tested_bit);
+    compiler::Label skip_copy;
+    __ AndImmediate(TMP, length_reg, 1 << tested_bit);
+    __ BranchEqual(TMP, ZR, &skip_copy);
+    for (intptr_t j = 0; j < bytes; j++) {
+      CopyBytes(compiler, dest_reg, src_reg, 1, reversed, temp);
+    }
+    __ Bind(&skip_copy);
+  }
+
+  ASSERT(tested_bits != 0);
+  __ AndImmediate(length_reg, length_reg, ~tested_bits);
+  __ BranchEqual(length_reg, ZR, done);
+}
+
 void MemoryCopyInstr::EmitLoopCopy(FlowGraphCompiler* compiler,
                                    Register dest_reg,
                                    Register src_reg,

--- a/runtime/vm/compiler/backend/il_mips.cc
+++ b/runtime/vm/compiler/backend/il_mips.cc
@@ -586,6 +586,106 @@ void BoxInteger32Instr::EmitNativeCode(FlowGraphCompiler* compiler) {
   }
 }
 
+LocationSummary* BoxInt64Instr::MakeLocationSummary(Zone* zone,
+                                                    bool opt) const {
+  const intptr_t kNumInputs = 1;
+  const intptr_t kNumTemps = ValueFitsSmi() ? 0 : 1;
+  // Shared slow path is used in BoxInt64Instr::EmitNativeCode in
+  // precompiled mode and only after VM isolate stubs where
+  // replaced with isolate-specific stubs.
+  auto object_store = IsolateGroup::Current()->object_store();
+  const bool stubs_in_vm_isolate =
+      object_store->allocate_mint_with_fpu_regs_stub()
+          ->untag()
+          ->InVMIsolateHeap() ||
+      object_store->allocate_mint_without_fpu_regs_stub()
+          ->untag()
+          ->InVMIsolateHeap();
+  const bool shared_slow_path_call =
+      SlowPathSharingSupported(opt) && !stubs_in_vm_isolate;
+  LocationSummary* summary = new (zone) LocationSummary(
+      zone, kNumInputs, kNumTemps,
+      ValueFitsSmi()
+          ? LocationSummary::kNoCall
+          : ((shared_slow_path_call ? LocationSummary::kCallOnSharedSlowPath
+                                    : LocationSummary::kCallOnSlowPath)));
+  summary->set_in(0, Location::Pair(Location::RequiresRegister(),
+                                    Location::RequiresRegister()));
+  if (ValueFitsSmi()) {
+    summary->set_out(0, Location::RequiresRegister());
+  } else if (shared_slow_path_call) {
+    summary->set_out(0,
+                     Location::RegisterLocation(AllocateMintABI::kResultReg));
+    summary->set_temp(0, Location::RegisterLocation(AllocateMintABI::kTempReg));
+  } else {
+    summary->set_out(0, Location::RequiresRegister());
+    summary->set_temp(0, Location::RequiresRegister());
+  }
+  return summary;
+}
+
+void BoxInt64Instr::EmitNativeCode(FlowGraphCompiler* compiler) {
+  if (ValueFitsSmi()) {
+    PairLocation* value_pair = locs()->in(0).AsPairLocation();
+    Register value_lo = value_pair->At(0).reg();
+    Register out_reg = locs()->out(0).reg();
+    __ SmiTag(out_reg, value_lo);
+    return;
+  }
+
+  PairLocation* value_pair = locs()->in(0).AsPairLocation();
+  Register value_lo = value_pair->At(0).reg();
+  Register value_hi = value_pair->At(1).reg();
+  Register tmp = locs()->temp(0).reg();
+  Register out_reg = locs()->out(0).reg();
+
+  compiler::Label not_smi, done;
+  __ SmiTag(out_reg, value_lo);
+  __ SmiUntag(tmp, out_reg);
+  __ bne(tmp, value_lo, &not_smi);
+  __ delay_slot()->sra(tmp, out_reg, 31);
+  __ beq(tmp, value_hi, &done);
+
+  __ Bind(&not_smi);
+
+  if (compiler->intrinsic_mode()) {
+    __ TryAllocate(compiler->mint_class(),
+                   compiler->intrinsic_slow_path_label(),
+                   compiler::Assembler::kNearJump, out_reg, tmp);
+  } else if (locs()->call_on_shared_slow_path()) {
+    const bool has_frame = compiler->flow_graph().graph_entry()->NeedsFrame();
+    if (!has_frame) {
+      ASSERT(__ constant_pool_allowed());
+      __ set_constant_pool_allowed(false);
+      __ EnterDartFrame(0);
+    }
+    auto object_store = compiler->isolate_group()->object_store();
+    const bool live_fpu_regs = locs()->live_registers()->FpuRegisterCount() > 0;
+    const auto& stub = Code::ZoneHandle(
+        compiler->zone(),
+        live_fpu_regs ? object_store->allocate_mint_with_fpu_regs_stub()
+                      : object_store->allocate_mint_without_fpu_regs_stub());
+
+    ASSERT(!locs()->live_registers()->ContainsRegister(
+        AllocateMintABI::kResultReg));
+    auto extended_env = compiler->SlowPathEnvironmentFor(this, 0);
+    compiler->GenerateStubCall(source(), stub, UntaggedPcDescriptors::kOther,
+                               locs(), DeoptId::kNone, extended_env);
+    if (!has_frame) {
+      __ LeaveDartFrame();
+      __ set_constant_pool_allowed(true);
+    }
+  } else {
+    BoxAllocationSlowPath::Allocate(compiler, this, compiler->mint_class(),
+                                    out_reg, tmp);
+  }
+
+  __ StoreToOffset(value_lo, out_reg, Mint::value_offset() - kHeapObjectTag);
+  __ StoreToOffset(value_hi, out_reg,
+                   Mint::value_offset() - kHeapObjectTag + kWordSize);
+  __ Bind(&done);
+}
+
 LocationSummary* UnboxInteger32Instr::MakeLocationSummary(Zone* zone,
                                                           bool opt) const {
   ASSERT((representation() == kUnboxedInt32) ||

--- a/runtime/vm/compiler/backend/il_mips.cc
+++ b/runtime/vm/compiler/backend/il_mips.cc
@@ -745,6 +745,40 @@ void UnboxInteger32Instr::EmitNativeCode(FlowGraphCompiler* compiler) {
   }
 }
 
+LocationSummary* BinaryDoubleOpInstr::MakeLocationSummary(Zone* zone,
+                                                          bool opt) const {
+  const intptr_t kNumInputs = 2;
+  const intptr_t kNumTemps = 0;
+  LocationSummary* summary = new (zone)
+      LocationSummary(zone, kNumInputs, kNumTemps, LocationSummary::kNoCall);
+  summary->set_in(0, Location::RequiresFpuRegister());
+  summary->set_in(1, Location::RequiresFpuRegister());
+  summary->set_out(0, Location::RequiresFpuRegister());
+  return summary;
+}
+
+void BinaryDoubleOpInstr::EmitNativeCode(FlowGraphCompiler* compiler) {
+  DRegister left = locs()->in(0).fpu_reg();
+  DRegister right = locs()->in(1).fpu_reg();
+  DRegister result = locs()->out(0).fpu_reg();
+  switch (op_kind()) {
+    case Token::kADD:
+      __ addd(result, left, right);
+      break;
+    case Token::kSUB:
+      __ subd(result, left, right);
+      break;
+    case Token::kMUL:
+      __ muld(result, left, right);
+      break;
+    case Token::kDIV:
+      __ divd(result, left, right);
+      break;
+    default:
+      UNREACHABLE();
+  }
+}
+
 }  // namespace dart
 
 #endif  // defined TARGET_ARCH_MIPS

--- a/runtime/vm/compiler/backend/il_mips.cc
+++ b/runtime/vm/compiler/backend/il_mips.cc
@@ -848,6 +848,15 @@ Condition DoubleTestOpInstr::EmitConditionCode(FlowGraphCompiler* compiler,
   }
 }
 
+LocationSummary* SimdOpInstr::MakeLocationSummary(Zone* zone, bool opt) const {
+  UNIMPLEMENTED();
+  return nullptr;
+}
+
+void SimdOpInstr::EmitNativeCode(FlowGraphCompiler* compiler) {
+  UNIMPLEMENTED();
+}
+
 }  // namespace dart
 
 #endif  // defined TARGET_ARCH_MIPS

--- a/runtime/vm/compiler/backend/il_mips.cc
+++ b/runtime/vm/compiler/backend/il_mips.cc
@@ -15,6 +15,154 @@
 
 namespace dart {
 
+LocationSummary* MemoryCopyInstr::MakeLocationSummary(Zone* zone,
+                                                      bool opt) const {
+  // The compiler must optimize any function that includes a MemoryCopy
+  // instruction that uses typed data cids, since extracting the payload address
+  // from views is done in a compiler pass after all code motion has happened.
+  ASSERT((!IsTypedDataBaseClassId(src_cid_) &&
+          !IsTypedDataBaseClassId(dest_cid_)) ||
+         opt);
+  const intptr_t kNumInputs = 5;
+  const intptr_t kNumTemps = 3;
+  LocationSummary* locs = new (zone)
+      LocationSummary(zone, kNumInputs, kNumTemps, LocationSummary::kNoCall);
+  locs->set_in(kSrcPos, Location::RequiresRegister());
+  locs->set_in(kDestPos, Location::RequiresRegister());
+  locs->set_in(kSrcStartPos, LocationRegisterOrConstant(src_start()));
+  locs->set_in(kDestStartPos, LocationRegisterOrConstant(dest_start()));
+  locs->set_in(kLengthPos,
+               LocationWritableRegisterOrSmiConstant(length(), 0, 4));
+  locs->set_temp(0, Location::RequiresRegister());
+  locs->set_temp(1, Location::RequiresRegister());
+  locs->set_temp(2, Location::RequiresRegister());
+  return locs;
+}
+
+void MemoryCopyInstr::PrepareLengthRegForLoop(FlowGraphCompiler* compiler,
+                                              Register length_reg,
+                                              compiler::Label* done) {
+  __ BranchEqual(length_reg, ZR, done);
+}
+
+void MemoryCopyInstr::EmitLoopCopy(FlowGraphCompiler* compiler,
+                                   Register dest_reg,
+                                   Register src_reg,
+                                   Register length_reg,
+                                   compiler::Label* done,
+                                   compiler::Label* copy_forwards) {
+  const bool reversed = copy_forwards != nullptr;
+  const Register temp = locs()->temp(2).reg();
+  if (reversed) {
+    // Verify that the overlap actually exists by checking to see if the start
+    // of the destination region is after the end of the source region.
+    const intptr_t shift = Utils::ShiftForPowerOfTwo(element_size_) -
+                           (unboxed_inputs() ? 0 : kSmiTagShift);
+
+    if (shift == 0) {
+      __ addu(TMP, src_reg, length_reg);
+    } else if (shift < 0) {
+      __ sra(TMP, length_reg, -shift);
+      __ addu(TMP, src_reg, TMP);
+    } else {
+      __ sll(TMP, length_reg, shift);
+      __ addu(TMP, src_reg, TMP);
+    }
+    __ BranchUnsignedGreaterEqual(dest_reg, TMP, copy_forwards);
+    // Adjust dest_reg and src_reg to point at the end (i.e. one past the
+    // last element) of their respective region.
+    __ addu(dest_reg, dest_reg, TMP);
+    __ subu(dest_reg, dest_reg, src_reg);
+    __ MoveRegister(src_reg, TMP);
+  }
+  CopyUpToWordMultiple(compiler, dest_reg, src_reg, length_reg, element_size_,
+                       unboxed_inputs_, reversed, done, temp);
+  // The size of the uncopied region is a multiple of the word size, so now we
+  // copy the rest by word (unless the element size is larger).
+  const intptr_t loop_subtract =
+      Utils::Maximum<intptr_t>(1, compiler::target::kWordSize / element_size_)
+      << (unboxed_inputs_ ? 0 : kSmiTagShift);
+  __ Comment("Copying by multiples of word size");
+  compiler::Label loop;
+  __ Bind(&loop);
+  switch (element_size_) {
+    // Fall through for the sizes smaller than compiler::target::kWordSize.
+    case 1:
+      CopyBytes(compiler, dest_reg, src_reg, 1, reversed, temp);
+      CopyBytes(compiler, dest_reg, src_reg, 1, reversed, temp);
+      CopyBytes(compiler, dest_reg, src_reg, 1, reversed, temp);
+      CopyBytes(compiler, dest_reg, src_reg, 1, reversed, temp);
+      break;
+    case 2:
+      CopyBytes(compiler, dest_reg, src_reg, 2, reversed, temp);
+      CopyBytes(compiler, dest_reg, src_reg, 2, reversed, temp);
+      break;
+    case 4:
+      CopyBytes(compiler, dest_reg, src_reg, 4, reversed, temp);
+      break;
+    case 8:
+      CopyBytes(compiler, dest_reg, src_reg, 8, reversed, temp);
+      break;
+    case 16:
+      CopyBytes(compiler, dest_reg, src_reg, 16, reversed, temp);
+      break;
+    default:
+      UNREACHABLE();
+      break;
+  }
+  __ AddImmediate(length_reg, length_reg, -loop_subtract);
+  __ BranchNotEqual(length_reg, ZR, &loop);
+}
+
+void MemoryCopyInstr::EmitComputeStartPointer(FlowGraphCompiler* compiler,
+                                              classid_t array_cid,
+                                              Register array_reg,
+                                              Register payload_reg,
+                                              Representation array_rep,
+                                              Location start_loc) {
+  intptr_t offset = 0;
+  if (array_rep != kTagged) {
+    // Do nothing, array_reg already contains the payload address.
+  } else if (IsTypedDataBaseClassId(array_cid)) {
+    // The incoming array must have been proven to be an internal typed data
+    // object, where the payload is in the object and we can just offset.
+    ASSERT_EQUAL(array_rep, kTagged);
+    offset = compiler::target::TypedData::payload_offset() - kHeapObjectTag;
+  } else {
+    ASSERT_EQUAL(array_rep, kTagged);
+    ASSERT(!IsExternalPayloadClassId(array_cid));
+    switch (array_cid) {
+      case kOneByteStringCid:
+        offset =
+            compiler::target::OneByteString::data_offset() - kHeapObjectTag;
+        break;
+      case kTwoByteStringCid:
+        offset =
+            compiler::target::TwoByteString::data_offset() - kHeapObjectTag;
+        break;
+      default:
+        UNREACHABLE();
+        break;
+    }
+  }
+  ASSERT(start_loc.IsRegister() || start_loc.IsConstant());
+  if (start_loc.IsConstant()) {
+    const auto& constant = start_loc.constant();
+    ASSERT(constant.IsInteger());
+    const int64_t start_value = Integer::Cast(constant).Value();
+    const intptr_t add_value = Utils::AddWithWrapAround(
+        Utils::MulWithWrapAround<intptr_t>(start_value, element_size_), offset);
+    __ AddImmediate(payload_reg, array_reg, add_value);
+    return;
+  }
+  const Register start_reg = start_loc.reg();
+  intptr_t shift = Utils::ShiftForPowerOfTwo(element_size_) -
+                   (unboxed_inputs() ? 0 : kSmiTagShift);
+
+  __ AddShifted(payload_reg, array_reg, start_reg, shift);
+  __ AddImmediate(payload_reg, offset);
+}
+
 #define R(r) (1 << r)
 
 LocationSummary* FfiCallInstr::MakeLocationSummary(Zone* zone,

--- a/runtime/vm/compiler/backend/il_mips.cc
+++ b/runtime/vm/compiler/backend/il_mips.cc
@@ -779,6 +779,75 @@ void BinaryDoubleOpInstr::EmitNativeCode(FlowGraphCompiler* compiler) {
   }
 }
 
+LocationSummary* DoubleTestOpInstr::MakeLocationSummary(Zone* zone,
+                                                        bool opt) const {
+  const intptr_t kNumInputs = 1;
+  const intptr_t kNumTemps = 0;
+  LocationSummary* summary = new (zone)
+      LocationSummary(zone, kNumInputs, kNumTemps, LocationSummary::kNoCall);
+  summary->set_in(0, Location::RequiresFpuRegister());
+  summary->set_out(0, Location::RequiresRegister());
+  return summary;
+}
+
+Condition DoubleTestOpInstr::EmitConditionCode(FlowGraphCompiler* compiler,
+                                                BranchLabels labels) {
+  ASSERT(compiler->is_optimizing());
+  const DRegister value = locs()->in(0).fpu_reg();
+  const bool is_negated = kind() != Token::kEQ;
+  if (op_kind() == MethodRecognizer::kDouble_getIsNaN) {
+    __ cund(value, value);
+    if (labels.fall_through == labels.true_label) {
+      if (is_negated) {
+        __ bc1t(labels.false_label);
+      } else {
+        __ bc1f(labels.false_label);
+      }
+    } else if (labels.fall_through == labels.false_label) {
+      if (is_negated) {
+        __ bc1f(labels.true_label);
+      } else {
+        __ bc1t(labels.true_label);
+      }
+    } else {
+      if (is_negated) {
+        __ bc1t(labels.false_label);
+      } else {
+        __ bc1f(labels.false_label);
+      }
+      __ b(labels.true_label);
+    }
+    return kInvalidCondition;  // Unused.
+  } else if(op_kind() == MethodRecognizer::kDouble_getIsInfinite){
+    __ mfc1(CMPRES1, EvenFRegisterOf(value));
+    // If the low word isn't zero, then it isn't infinity.
+    __ bne(CMPRES1, ZR, is_negated ? labels.true_label : labels.false_label);
+    __ mfc1(CMPRES1, OddFRegisterOf(value));
+    // Mask off the sign bit.
+    __ AndImmediate(CMPRES1, CMPRES1, 0x7FFFFFFF);
+    // Compare with +infinity.
+    __ LoadImmediate(CMPRES2, 0x7FF00000);
+    __ CompareRegisters(CMPRES1, CMPRES2);
+    return is_negated ? NE : EQ;
+  } else if(op_kind() == MethodRecognizer::kDouble_getIsNegative){
+    ASSERT(value!=FpuTMP);
+    compiler::Label oddIsNotZero;
+    __ cund(value, value);
+    // If it's NaN, it's not negative.
+    __ bc1t(is_negated ? labels.true_label : labels.false_label);
+
+    // Move the high 32 bits of the double into a general-purpose register.
+    __ mfc1(CMPRES1, OddFRegisterOf(value));
+
+    // High word has sign bit = 1 for negative doubles.
+    // Comparing with zero as int works because signed ints also use MSB as sign (two's complement).
+    __ CompareRegisters(CMPRES1, ZR);
+    return is_negated ? GE : LT;
+  } else {
+    UNREACHABLE();
+  }
+}
+
 }  // namespace dart
 
 #endif  // defined TARGET_ARCH_MIPS

--- a/runtime/vm/compiler/backend/il_mips.cc
+++ b/runtime/vm/compiler/backend/il_mips.cc
@@ -39,6 +39,23 @@ LocationSummary* MemoryCopyInstr::MakeLocationSummary(Zone* zone,
   return locs;
 }
 
+static compiler::OperandSize OperandSizeFor(intptr_t bytes) {
+  ASSERT(Utils::IsPowerOfTwo(bytes));
+  switch (bytes) {
+    case 1:
+      return compiler::kUnsignedByte;
+    case 2:
+      return compiler::kUnsignedTwoBytes;
+    case 4:
+      return compiler::kUnsignedFourBytes;
+    case 8:
+      return compiler::kEightBytes;
+    default:
+      UNREACHABLE();
+      return compiler::kEightBytes;
+  }
+}
+
 void MemoryCopyInstr::PrepareLengthRegForLoop(FlowGraphCompiler* compiler,
                                               Register length_reg,
                                               compiler::Label* done) {


### PR DESCRIPTION
This PR extends the MIPS backend with:

-     Memory copy:

        Implemented MemoryCopyInstr with location summaries and looped copy.
        Handles overlapping ranges, multiple element sizes, tagged and unboxed inputs.
        Added CopyBytes, CopyUpToWordMultiple, and OperandSizeFor helpers.

-     Boxing / unboxing:

        Added UnboxInstr locations and codegen for ints and floats (32‑ and 64‑bit).
        Implemented int32/uint32 boxing/unboxing with Smi fast path and Mint fallback.
        Implemented int64 boxing with Smi fast path and Mint allocation (intrinsic and slow path).

-     Double operations:

        Implemented BinaryDoubleOpInstr (ADD, SUB, MUL, DIV) using FPU registers.
        Implemented DoubleTestOpInstr for isNaN, isInfinite, and isNegative.

-     Comparisons and boolean ops:

        Implemented equality and strict compares for Smi, Mint, Integer, and Double, including null‑aware behavior.
        Implemented boolean negation using branch‑free bitwise XOR.

-     SIMD stubs:

        Added unimplemented stubs for SimdOpInstr (location summaries and codegen placeholders).
