### PR TITLE
[mips] Add assembler functions

### DIFF
--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -813,6 +813,52 @@ void Assembler::Bind(Label* label) {
   delay_slot_available_ = false;
 }
 
+void Assembler::PushNativeCalleeSavedRegisters() {
+  RegisterSet regs(kAbiPreservedCpuRegs, kAbiPreservedFpuRegs);
+  intptr_t size = (regs.CpuRegisterCount() * target::kWordSize) +
+                  (regs.FpuRegisterCount() * sizeof(double));
+  AddImmediate(SP, SP, -size);
+  intptr_t offset = 0;
+  for (intptr_t i = 0; i < kNumberOfFpuRegisters; i++) {
+    FpuRegister reg = static_cast<FpuRegister>(i);
+    if (regs.ContainsFpuRegister(reg)) {
+      sdc1(reg, Address(SP, offset));
+      offset += sizeof(double);
+    }
+  }
+  for (intptr_t i = 0; i < kNumberOfCpuRegisters; i++) {
+    Register reg = static_cast<Register>(i);
+    if (regs.ContainsRegister(reg)) {
+      sw(reg, Address(SP, offset));
+      offset += target::kWordSize;
+    }
+  }
+  ASSERT(offset == size);
+}
+
+void Assembler::PopNativeCalleeSavedRegisters() {
+  RegisterSet regs(kAbiPreservedCpuRegs, kAbiPreservedFpuRegs);
+  intptr_t size = (regs.CpuRegisterCount() * target::kWordSize) +
+                  (regs.FpuRegisterCount() * sizeof(double));
+  intptr_t offset = 0;
+  for (intptr_t i = 0; i < kNumberOfFpuRegisters; i++) {
+    FpuRegister reg = static_cast<FpuRegister>(i);
+    if (regs.ContainsFpuRegister(reg)) {
+      ldc1(reg, Address(SP, offset));
+      offset += sizeof(double);
+    }
+  }
+  for (intptr_t i = 0; i < kNumberOfCpuRegisters; i++) {
+    Register reg = static_cast<Register>(i);
+    if (regs.ContainsRegister(reg)) {
+      lw(reg, Address(SP, offset));
+      offset += target::kWordSize;
+    }
+  }
+  ASSERT(offset == size);
+  AddImmediate(SP, SP, size);
+}
+
 Address Assembler::PrepareLargeOffset(Register base, int32_t offset) {
   ASSERT(!in_delay_slot_);
   if (Utils::IsInt(kImmBits, offset)) {

--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -883,17 +883,36 @@ void Assembler::RangeCheck(Register value,
 }
 
 void Assembler::LoadClassId(Register result, Register object) {
-  UNIMPLEMENTED();
+  ASSERT_EQUAL(target::UntaggedObject::kClassIdTagPos, 12);
+  ASSERT_EQUAL(target::UntaggedObject::kClassIdTagSize, 20);
+  lw(result, FieldAddress(object, target::Object::tags_offset()));
+  ExtractClassIdFromTags(result, result);
 }
 
 void Assembler::LoadClassById(Register result, Register class_id) {
-  UNIMPLEMENTED();
+  ASSERT(!in_delay_slot_);
+  ASSERT(result != class_id);
+  LoadIsolateGroup(result);
+  const intptr_t offset = target::IsolateGroup::cached_class_table_table_offset();
+  LoadFromOffset(result, result, offset);
+  sll(TMP, class_id, 2);
+  addu(result, result, TMP);
+  lw(result, Address(result));
+}
+
+void Assembler::LoadClass(Register result, Register object) {
+  ASSERT(!in_delay_slot_);
+  ASSERT(TMP != result);
+  LoadClassId(TMP, object);
+  LoadClassById(result, TMP);
 }
 
 void Assembler::CompareClassId(Register object,
                                intptr_t class_id,
                                Register scratch) {
-  UNIMPLEMENTED();
+  ASSERT(scratch != kNoRegister);
+  LoadClassId(scratch, object);
+  CompareImmediate(scratch, class_id);
 }
 
 void Assembler::LoadClassIdMayBeSmi(Register result, Register object) {

--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -981,6 +981,14 @@ void Assembler::Load(Register dest, const Address& address, OperandSize sz) {
   }
 }
 
+void Assembler::LoadSImmediate(DRegister reg, float imms) {
+  int32_t imm = bit_cast<int32_t, float>(imms);
+  ASSERT(constant_pool_allowed());
+  intptr_t index = object_pool_builder().FindImmediate(imm);
+  intptr_t offset = target::ObjectPool::element_offset(index) - kHeapObjectTag;
+  LoadSFromOffset(reg, PP, offset);
+}
+
 void Assembler::LoadWordFromPoolIndex(Register rd,
                                       intptr_t index,
                                       Register pp) {

--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -867,6 +867,14 @@ void Assembler::LoadUniqueObject(Register rd, const Object& object,
   LoadObjectHelper(rd, object, true, snapshot_behavior);
 }
 
+void Assembler::LoadNativeEntry(Register rd,
+                                const ExternalLabel* label,
+                                ObjectPoolBuilderEntry::Patchability patchable) {
+  const intptr_t index =
+      object_pool_builder().FindNativeFunction(label, patchable);
+  LoadWordFromPoolIndex(rd, index);
+}
+
 void Assembler::RangeCheck(Register value,
                            Register temp,
                            intptr_t low,

--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -1434,6 +1434,25 @@ void Assembler::LeaveStubFrameAndReturn(Register ra) {
   LeaveDartFrameAndReturn(ra);
 }
 
+void Assembler::EnterCFrame(intptr_t frame_space) {
+  // Already saved.
+  COMPILE_ASSERT(IsCalleeSavedRegister(THR));
+  COMPILE_ASSERT(IsCalleeSavedRegister(PP));
+
+  EnterFrame();
+  /*A caller reserves four words (16 bytes) at the end of its stack frame for the callee to store its
+  arguments, even if the callee takes fewer than four arguments, even if the callee does not
+  actually use this space. In other words, if you are a non-leaf function, then you must never
+  address 0(sp), 4(sp), 8(sp), or 12(sp)! However, supposing your frame is 32 bytes, then you
+  may use 32(sp), 36(sp), 40(sp), and 44(sp) for storing a0, a1, a2, and a3, respectively, even
+  though this is in the frame of your caller!*/
+  ReserveAlignedFrameSpace(frame_space + 4 * target::kWordSize);
+}
+
+void Assembler::LeaveCFrame() {
+  LeaveFrame();
+}
+
 void Assembler::EnterDartFrame(intptr_t frame_size, bool load_pool_pointer) {
   ASSERT(!in_delay_slot_);
 

--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -539,6 +539,89 @@ void Assembler::BranchIfBit(Register rn,
   }
 }
 
+Address Assembler::ElementAddressForIntIndex(bool is_external,
+                                            intptr_t cid,
+                                            intptr_t index_scale,
+                                            Register array,
+                                            intptr_t index) const {
+  const int64_t offset =
+      static_cast<int64_t>(index) * index_scale +
+      (is_external ? 0 : (target::Instance::DataOffsetFor(cid) - kHeapObjectTag));
+  ASSERT(Utils::IsInt(32, offset));
+  ASSERT(Address::CanHoldOffset(offset));
+  return Address(array, static_cast<int32_t>(offset));
+}
+
+void Assembler::LoadElementAddressForIntIndex(Register address,
+                                              bool is_external,
+                                              intptr_t cid,
+                                              intptr_t index_scale,
+                                              Register array,
+                                              intptr_t index) {
+  const int64_t offset =
+      static_cast<int64_t>(index) * index_scale +
+      (is_external ? 0 : (target::Instance::DataOffsetFor(cid) - kHeapObjectTag));
+  ASSERT(Utils::IsInt(32, offset));
+  AddImmediate(address, array, offset);
+}
+
+Address Assembler::ElementAddressForRegIndex(bool is_load,
+                                            bool is_external,
+                                            intptr_t cid,
+                                            intptr_t index_scale,
+                                            bool index_unboxed,
+                                            Register array,
+                                            Register index) {
+  // Note that index is expected smi-tagged, (i.e, LSL 1) for all arrays.
+  const intptr_t boxing_shift = index_unboxed ? 0 : -kSmiTagShift;
+  const intptr_t shift = Utils::ShiftForPowerOfTwo(index_scale) + boxing_shift;
+  const int32_t offset =
+      is_external ? 0 : (target::Instance::DataOffsetFor(cid) - kHeapObjectTag);
+  ASSERT(array != TMP);
+  ASSERT(index != TMP);
+  const Register base = is_load ? TMP : index;
+  if (shift < 0) {
+    ASSERT(shift == -1);
+    sra(TMP, index, 1);
+    addu(base, array, TMP);
+  } else if (shift == 0) {
+    addu(base, array, index);
+  } else {
+    sll(TMP, index, shift);
+    addu(base, array, TMP);
+  }
+  ASSERT(Address::CanHoldOffset(offset));
+  return Address(base, offset);
+}
+
+void Assembler::LoadElementAddressForRegIndex(Register address,
+                                              bool is_load,
+                                              bool is_external,
+                                              intptr_t cid,
+                                              intptr_t index_scale,
+                                              bool index_unboxed,
+                                              Register array,
+                                              Register index) {
+  // Note that index is expected smi-tagged, (i.e, LSL 1) for all arrays.
+  const intptr_t boxing_shift = index_unboxed ? 0 : -kSmiTagShift;
+  const intptr_t shift = Utils::ShiftForPowerOfTwo(index_scale) + boxing_shift;
+  const int32_t offset =
+      is_external ? 0 : (target::Instance::DataOffsetFor(cid) - kHeapObjectTag);
+  if (shift < 0) {
+    ASSERT(shift == -1);
+    sra(address, index, 1);
+    addu(address, array, address);
+  } else if (shift == 0) {
+    addu(address, array, index);
+  } else {
+    sll(address, index, shift);
+    addu(address, array, address);
+  }
+  if (offset != 0) {
+    AddImmediate(address, offset);
+  }
+}
+
 void Assembler::SetIf(Condition condition, Register rd) {
   ASSERT(deferred_compare_ != kNone);
 

--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -15,8 +15,146 @@ DECLARE_FLAG(bool, check_code_pointer);
 
 namespace compiler{
 
+static bool CanEncodeBranchOffset(int32_t offset) {
+  ASSERT(Utils::IsAligned(offset, 4));
+  return Utils::IsInt(18, offset);
+}
+
+int32_t Assembler::EncodeBranchOffset(int32_t offset, int32_t instr) {
+  ASSERT(Utils::IsAligned(offset, 4));
+  ASSERT(Utils::IsInt(18, offset));
+
+  // Properly preserve only the bits supported in the instruction.
+  offset >>= 2;
+  offset &= kBranchOffsetMask;
+  return (instr & ~kBranchOffsetMask) | offset;
+}
+
+int32_t Assembler::DecodeBranchOffset(int32_t instr) {
+  // Sign-extend, left-shift by 2.
+  return (((instr & kBranchOffsetMask) << 16) >> 14);
+}
+
+static int32_t DecodeLoadImmediate(int32_t ori_instr, int32_t lui_instr) {
+  return (((lui_instr & kBranchOffsetMask) << 16) |
+          (ori_instr & kBranchOffsetMask));
+}
+
+static int32_t EncodeLoadImmediate(int32_t dest, int32_t instr) {
+  return ((instr & ~kBranchOffsetMask) | (dest & kBranchOffsetMask));
+}
+
+class PatchFarJump : public AssemblerFixup {
+ public:
+  PatchFarJump() {}
+
+  void Process(const MemoryRegion& region, intptr_t position) {
+    const int32_t high = region.Load<int32_t>(position);
+    const int32_t low = region.Load<int32_t>(position + Instr::kInstrSize);
+    const int32_t offset = DecodeLoadImmediate(low, high);
+    const int32_t dest = region.start() + offset;
+
+    if ((Instr::At(reinterpret_cast<uword>(&high))->OpcodeField() == LUI) &&
+        (Instr::At(reinterpret_cast<uword>(&low))->OpcodeField() == ORI)) {
+      // Change the offset to the absolute value.
+      const int32_t encoded_low =
+          EncodeLoadImmediate(dest & kBranchOffsetMask, low);
+      const int32_t encoded_high = EncodeLoadImmediate(dest >> 16, high);
+
+      region.Store<int32_t>(position, encoded_high);
+      region.Store<int32_t>(position + Instr::kInstrSize, encoded_low);
+      return;
+    }
+    // If the offset loading instructions aren't there, we must have replaced
+    // the far branch with a near one, and so these instructions should be NOPs.
+    ASSERT((high == Instr::kNopInstruction) && (low == Instr::kNopInstruction));
+  }
+
+  virtual bool IsPointerOffset() const { return false; }
+};
+
+void Assembler::EmitFarJump(int32_t offset, bool link) {
+  ASSERT(!in_delay_slot_);
+  ASSERT(use_far_branches());
+  const uint16_t low = Utils::Low16Bits(offset);
+  const uint16_t high = Utils::High16Bits(offset);
+  buffer_.EmitFixup(new PatchFarJump());
+  lui(T9, Immediate(high));
+  ori(T9, T9, Immediate(low));
+  if (link) {
+    EmitRType(SPECIAL, T9, R0, RA, 0, JALR);
+  } else {
+    EmitRType(SPECIAL, T9, R0, R0, 0, JR);
+  }
+}
+
+static Opcode OppositeBranchOpcode(Opcode b) {
+  switch (b) {
+    case BEQ:
+      return BNE;
+    case BNE:
+      return BEQ;
+    case BGTZ:
+      return BLEZ;
+    case BLEZ:
+      return BGTZ;
+    case BEQL:
+      return BNEL;
+    case BNEL:
+      return BEQL;
+    case BGTZL:
+      return BLEZL;
+    case BLEZL:
+      return BGTZL;
+    default:
+      UNREACHABLE();
+      break;
+  }
+  return BNE;
+}
+
+void Assembler::EmitFarBranch(Opcode b,
+                              Register rs,
+                              Register rt,
+                              int32_t offset) {
+  ASSERT(!in_delay_slot_);
+  EmitIType(b, rs, rt, 4);
+  nop();
+  EmitFarJump(offset, false);
+}
+
 void Assembler::EmitBranch(Opcode b, Register rs, Register rt, Label* label) {
-  UNIMPLEMENTED();
+  ASSERT(!in_delay_slot_);
+  if (label->IsBound()) {
+    // Relative destination from an instruction after the branch.
+    const int32_t dest =
+        label->Position() - (buffer_.Size() + Instr::kInstrSize);
+    if (use_far_branches() && !CanEncodeBranchOffset(dest)) {
+      EmitFarBranch(OppositeBranchOpcode(b), rs, rt, label->Position());
+    } else {
+      BailoutIfInvalidBranchOffset(dest);
+      const uint16_t dest_off = EncodeBranchOffset(dest, 0);
+      EmitIType(b, rs, rt, dest_off);
+    }
+  } else {
+    const intptr_t position = buffer_.Size();
+    if (use_far_branches()) {
+      const uint32_t dest_off = label->position_;
+      EmitFarBranch(b, rs, rt, dest_off);
+    } else {
+      BailoutIfInvalidBranchOffset(label->position_);
+      const uint16_t dest_off = EncodeBranchOffset(label->position_, 0);
+      EmitIType(b, rs, rt, dest_off);
+    }
+    label->LinkTo(position);
+  }
+}
+
+void Assembler::BailoutIfInvalidBranchOffset(int32_t offset) {
+  if (!CanEncodeBranchOffset(offset)) {
+    ASSERT(!use_far_branches());
+    BailoutWithBranchOffsetError();
+  }
 }
 
 void Assembler::EmitRegImmBranch(RtRegImm b, Register rs, Label* label) {

--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -879,6 +879,49 @@ void Assembler::AddBranchOverflow(Register rd,
   }
 }
 
+void Assembler::SubtractBranchOverflow(Register rd,
+                                       Register rs1,
+                                       Register rs2,
+                                       Label* overflow) {
+  ASSERT(rd != CMPRES1);
+  ASSERT(rd != CMPRES2);
+  ASSERT(rs1 != CMPRES1);
+  ASSERT(rs1 != CMPRES2);
+  ASSERT(rs2 != CMPRES1);
+  ASSERT(rs2 != CMPRES2);
+
+  if ((rd == rs1) && (rd == rs2)) {
+    ASSERT(rs1 == rs2);
+    mov(CMPRES1, rs1);
+    subu(rd, rs1, rs2);   // rs1, rs2 destroyed
+    xor_(CMPRES1, CMPRES1, rd);  // CMPRES1 negative if sign changed
+    bltz(CMPRES1, overflow);
+  } else if (rs1 == rs2) {
+    ASSERT(rd != rs1);
+    ASSERT(rd != rs2);
+    subu(rd, rs1, rs2);
+    xor_(CMPRES1, rd, rs1);  // CMPRES1 negative if sign changed
+    bltz(CMPRES1, overflow);
+  } else if (rd == rs1) {
+    ASSERT(rs1 != rs2);
+    slti(CMPRES1, rs1, Immediate(0));
+    subu(rd, rs1, rs2);  // rs1 destroyed
+    slt(CMPRES2, rd, rs2);
+    bne(CMPRES1, CMPRES2, overflow);
+  } else if (rd == rs2) {
+    ASSERT(rs1 != rs2);
+    slti(CMPRES1, rs2, Immediate(0));
+    subu(rd, rs1, rs2);  // rs2 destroyed
+    slt(CMPRES2, rd, rs1);
+    bne(CMPRES1, CMPRES2, overflow);
+  } else {
+    subu(rd, rs1, rs2);
+    slti(CMPRES1, rs2, Immediate(0));
+    slt(CMPRES2, rs1, rd);
+    bne(CMPRES1, CMPRES2, overflow);
+  }
+}
+
 bool Assembler::AddressCanHoldConstantIndex(const Object& constant,
                                             bool is_load,
                                             bool is_external,
@@ -897,6 +940,36 @@ bool Assembler::AddressCanHoldConstantIndex(const Object& constant,
     return false;
   }
   return Address::CanHoldOffset(static_cast<int32_t>(offset));
+}
+
+void Assembler::AddImmediateBranchOverflow(Register rd,
+                                           Register rs1,
+                                           int32_t imm,
+                                           Label* overflow) {
+  ASSERT(rd != CMPRES1);
+  if (rd == rs1) {
+    mov(CMPRES1, rs1);
+    AddImmediate(rd, rs1, imm);
+    if (imm > 0) {
+      BranchSignedLess(rd, CMPRES1, overflow);
+    } else if (imm < 0) {
+      BranchSignedGreater(rd, CMPRES1, overflow);
+    }
+  } else {
+    AddImmediate(rd, rs1, imm);
+    if (imm > 0) {
+      BranchSignedLess(rd, rs1, overflow);
+    } else if (imm < 0) {
+      BranchSignedGreater(rd, rs1, overflow);
+    }
+  }
+}
+
+void Assembler::SubtractImmediateBranchOverflow(Register rd,
+                                                Register rs1,
+                                                int32_t imm,
+                                                Label* overflow) {
+  AddImmediateBranchOverflow(rd, rs1, -imm, overflow);
 }
 
 void Assembler::Bind(Label* label) {
@@ -1288,6 +1361,14 @@ void Assembler::Store(Register reg, const Address& address, OperandSize sz) {
     default:
       UNREACHABLE();
   }
+}
+
+void Assembler::AndRegisters(Register dst, Register src1, Register src2) {
+  ASSERT(src1 != src2);
+  if (src2 == kNoRegister) {
+    src2 = dst;
+  }
+  and_(dst, src2, src1);
 }
 
 void Assembler::RestoreCodePointer() {

--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -123,6 +123,30 @@ void Assembler::EmitFarBranch(Opcode b,
   EmitFarJump(offset, false);
 }
 
+static RtRegImm OppositeBranchNoLink(RtRegImm b) {
+  switch (b) {
+    case BLTZ:
+      return BGEZ;
+    case BGEZ:
+      return BLTZ;
+    case BLTZAL:
+      return BGEZ;
+    case BGEZAL:
+      return BLTZ;
+    default:
+      UNREACHABLE();
+      break;
+  }
+  return BLTZ;
+}
+
+void Assembler::EmitFarRegImmBranch(RtRegImm b, Register rs, int32_t offset) {
+  ASSERT(!in_delay_slot_);
+  EmitRegImmType(REGIMM, rs, b, 4);
+  nop();
+  EmitFarJump(offset, (b == BLTZAL) || (b == BGEZAL));
+}
+
 void Assembler::EmitBranch(Opcode b, Register rs, Register rt, Label* label) {
   ASSERT(!in_delay_slot_);
   if (label->IsBound()) {
@@ -158,7 +182,30 @@ void Assembler::BailoutIfInvalidBranchOffset(int32_t offset) {
 }
 
 void Assembler::EmitRegImmBranch(RtRegImm b, Register rs, Label* label) {
-  UNIMPLEMENTED();
+  ASSERT(!in_delay_slot_);
+  if (label->IsBound()) {
+    // Relative destination from an instruction after the branch.
+    const int32_t dest =
+        label->Position() - (buffer_.Size() + Instr::kInstrSize);
+    if (use_far_branches() && !CanEncodeBranchOffset(dest)) {
+      EmitFarRegImmBranch(OppositeBranchNoLink(b), rs, label->Position());
+    } else {
+      BailoutIfInvalidBranchOffset(dest);
+      const uint16_t dest_off = EncodeBranchOffset(dest, 0);
+      EmitRegImmType(REGIMM, rs, b, dest_off);
+    }
+  } else {
+    const intptr_t position = buffer_.Size();
+    if (use_far_branches()) {
+      const uint32_t dest_off = label->position_;
+      EmitFarRegImmBranch(b, rs, dest_off);
+    } else {
+      BailoutIfInvalidBranchOffset(label->position_);
+      const uint16_t dest_off = EncodeBranchOffset(label->position_, 0);
+      EmitRegImmType(REGIMM, rs, b, dest_off);
+    }
+    label->LinkTo(position);
+  }
 }
 
 void Assembler::EmitFpuBranch(bool kind, Label* label) {

--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -989,6 +989,22 @@ void Assembler::LoadSImmediate(DRegister reg, float imms) {
   LoadSFromOffset(reg, PP, offset);
 }
 
+void Assembler::LoadDImmediate(DRegister reg, double immd, Register scratch) {
+  ASSERT(scratch != TMP);
+  int64_t imm = bit_cast<int64_t, double>(immd);
+  if (constant_pool_allowed()) {
+    intptr_t index = object_pool_builder().FindImmediate64(imm);
+    intptr_t offset = target::ObjectPool::element_offset(index) - kHeapObjectTag;
+    LoadDFromOffset(reg, PP, offset);
+  } else {
+    ASSERT(scratch != kNoRegister);
+    LoadImmediate(TMP, Utils::Low32Bits(imm));
+    LoadImmediate(scratch, Utils::High32Bits(imm));
+    mtc1(TMP, static_cast<FRegister>(reg*2));
+    mtc1(scratch, static_cast<FRegister>(reg*2 + 1));
+  }
+}
+
 void Assembler::LoadWordFromPoolIndex(Register rd,
                                       intptr_t index,
                                       Register pp) {

--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -147,6 +147,14 @@ void Assembler::EmitFarRegImmBranch(RtRegImm b, Register rs, int32_t offset) {
   EmitFarJump(offset, (b == BLTZAL) || (b == BGEZAL));
 }
 
+void Assembler::EmitFarFpuBranch(bool kind, int32_t offset) {
+  ASSERT(!in_delay_slot_);
+  const uint32_t b16 = kind ? (1 << 16) : 0;
+  Emit(COP1 << kOpcodeShift | COP1_BC << kCop1SubShift | b16 | 4);
+  nop();
+  EmitFarJump(offset, false);
+}
+
 void Assembler::EmitBranch(Opcode b, Register rs, Register rt, Label* label) {
   ASSERT(!in_delay_slot_);
   if (label->IsBound()) {
@@ -209,7 +217,31 @@ void Assembler::EmitRegImmBranch(RtRegImm b, Register rs, Label* label) {
 }
 
 void Assembler::EmitFpuBranch(bool kind, Label* label) {
-  UNIMPLEMENTED();
+  ASSERT(!in_delay_slot_);
+  const int32_t b16 = kind ? (1 << 16) : 0;  // Bit 16 set for branch on true.
+  if (label->IsBound()) {
+    // Relative destination from an instruction after the branch.
+    const int32_t dest =
+        label->Position() - (buffer_.Size() + Instr::kInstrSize);
+    if (use_far_branches() && !CanEncodeBranchOffset(dest)) {
+      EmitFarFpuBranch(kind, label->Position());
+    } else {
+      BailoutIfInvalidBranchOffset(dest);
+      const uint16_t dest_off = EncodeBranchOffset(dest, 0);
+      Emit(COP1 << kOpcodeShift | COP1_BC << kCop1SubShift | b16 | dest_off);
+    }
+  } else {
+    const intptr_t position = buffer_.Size();
+    if (use_far_branches()) {
+      const uint32_t dest_off = label->position_;
+      EmitFarFpuBranch(kind, dest_off);
+    } else {
+      BailoutIfInvalidBranchOffset(label->position_);
+      const uint16_t dest_off = EncodeBranchOffset(label->position_, 0);
+      Emit(COP1 << kOpcodeShift | COP1_BC << kCop1SubShift | b16 | dest_off);
+    }
+    label->LinkTo(position);
+  }
 }
 
 void Assembler::PushRegisters(const RegisterSet& registers) {

--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -244,6 +244,20 @@ void Assembler::EmitFpuBranch(bool kind, Label* label) {
   }
 }
 
+static int32_t FlipBranchInstruction(int32_t instr) {
+  Instr* i = Instr::At(reinterpret_cast<uword>(&instr));
+  if (i->OpcodeField() == REGIMM) {
+    RtRegImm b = OppositeBranchNoLink(i->RegImmFnField());
+    i->SetRegImmFnField(b);
+    return i->InstructionBits();
+  } else if (i->OpcodeField() == COP1) {
+    return instr ^ (1 << 16);
+  }
+  Opcode b = OppositeBranchOpcode(i->OpcodeField());
+  i->SetOpcodeField(b);
+  return i->InstructionBits();
+}
+
 void Assembler::PushRegisters(const RegisterSet& registers) {
   UNIMPLEMENTED();
 }
@@ -731,7 +745,72 @@ void Assembler::AddBranchOverflow(Register rd,
 }
 
 void Assembler::Bind(Label* label) {
-  UNIMPLEMENTED();
+  ASSERT(!label->IsBound());
+  intptr_t bound_pc = buffer_.Size();
+
+  while (label->IsLinked()) {
+    int32_t position = label->Position();
+    int32_t dest = bound_pc - (position + Instr::kInstrSize);
+
+    if (use_far_branches() && !CanEncodeBranchOffset(dest)) {
+      // Far branches are enabled and we can't encode the branch offset.
+
+      // Grab the branch instruction. We'll need to flip it later.
+      const int32_t branch = buffer_.Load<int32_t>(position);
+
+      // Grab instructions that load the offset.
+      const int32_t high =
+          buffer_.Load<int32_t>(position + 2 * Instr::kInstrSize);
+      const int32_t low =
+          buffer_.Load<int32_t>(position + 3 * Instr::kInstrSize);
+
+      // Change from relative to the branch to relative to the assembler buffer.
+      dest = buffer_.Size();
+      const int32_t encoded_low =
+          EncodeLoadImmediate(dest & kBranchOffsetMask, low);
+      const int32_t encoded_high = EncodeLoadImmediate(dest >> 16, high);
+
+      // Skip the unconditional far jump if the test fails by flipping the
+      // sense of the branch instruction.
+      buffer_.Store<int32_t>(position, FlipBranchInstruction(branch));
+      buffer_.Store<int32_t>(position + 2 * Instr::kInstrSize, encoded_high);
+      buffer_.Store<int32_t>(position + 3 * Instr::kInstrSize, encoded_low);
+      label->position_ = DecodeLoadImmediate(low, high);
+    } else if (use_far_branches() && CanEncodeBranchOffset(dest)) {
+      // We assembled a far branch, but we don't need it. Replace with a near
+      // branch.
+
+      // Grab the link to the next branch.
+      const int32_t high =
+          buffer_.Load<int32_t>(position + 2 * Instr::kInstrSize);
+      const int32_t low =
+          buffer_.Load<int32_t>(position + 3 * Instr::kInstrSize);
+
+      // Grab the original branch instruction.
+      int32_t branch = buffer_.Load<int32_t>(position);
+
+      // Clear out the old (far) branch.
+      for (int i = 0; i < 5; i++) {
+        buffer_.Store<int32_t>(position + i * Instr::kInstrSize,
+                               Instr::kNopInstruction);
+      }
+
+      // Calculate the new offset.
+      dest = dest - 4 * Instr::kInstrSize;
+      BailoutIfInvalidBranchOffset(dest);
+      const int32_t encoded = EncodeBranchOffset(dest, branch);
+      buffer_.Store<int32_t>(position + 4 * Instr::kInstrSize, encoded);
+      label->position_ = DecodeLoadImmediate(low, high);
+    } else {
+      const int32_t next = buffer_.Load<int32_t>(position);
+      BailoutIfInvalidBranchOffset(dest);
+      const int32_t encoded = EncodeBranchOffset(dest, next);
+      buffer_.Store<int32_t>(position, encoded);
+      label->position_ = DecodeBranchOffset(next);
+    }
+  }
+  label->BindTo(bound_pc);
+  delay_slot_available_ = false;
 }
 
 Address Assembler::PrepareLargeOffset(Register base, int32_t offset) {

--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -622,6 +622,58 @@ void Assembler::LoadElementAddressForRegIndex(Register address,
   }
 }
 
+void Assembler::LoadHalfWordUnaligned(Register dst,
+                                      Register addr,
+                                      Register tmp) {
+  ASSERT(dst != addr);
+  lbu(dst, Address(addr, 0));
+  lb(tmp, Address(addr, 1));
+  sll(tmp, tmp, 8);
+  or_(dst, dst, tmp);
+}
+
+void Assembler::LoadHalfWordUnsignedUnaligned(Register dst,
+                                              Register addr,
+                                              Register tmp) {
+  ASSERT(dst != addr);
+  lbu(dst, Address(addr, 0));
+  lbu(tmp, Address(addr, 1));
+  sll(tmp, tmp, 8);
+  or_(dst, dst, tmp);
+}
+
+void Assembler::StoreHalfWordUnaligned(Register src,
+                                       Register addr,
+                                       Register tmp) {
+  sb(src, Address(addr, 0));
+  srl(tmp, src, 8);
+  sb(tmp, Address(addr, 1));
+}
+
+void Assembler::LoadWordUnaligned(Register dst, Register addr, Register tmp) {
+  ASSERT(dst != addr);
+  lbu(dst, Address(addr, 0));
+  lbu(tmp, Address(addr, 1));
+  sll(tmp, tmp, 8);
+  or_(dst, dst, tmp);
+  lbu(tmp, Address(addr, 2));
+  sll(tmp, tmp, 16);
+  or_(dst, dst, tmp);
+  lbu(tmp, Address(addr, 3));
+  sll(tmp, tmp, 24);
+  or_(dst, dst, tmp);
+}
+
+void Assembler::StoreWordUnaligned(Register src, Register addr, Register tmp) {
+  sb(src, Address(addr, 0));
+  srl(tmp, src, 8);
+  sb(tmp, Address(addr, 1));
+  srl(tmp, src, 16);
+  sb(tmp, Address(addr, 2));
+  srl(tmp, src, 24);
+  sb(tmp, Address(addr, 3));
+}
+
 void Assembler::SetIf(Condition condition, Register rd) {
   ASSERT(deferred_compare_ != kNone);
 

--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -744,6 +744,26 @@ void Assembler::AddBranchOverflow(Register rd,
   }
 }
 
+bool Assembler::AddressCanHoldConstantIndex(const Object& constant,
+                                            bool is_load,
+                                            bool is_external,
+                                            intptr_t cid,
+                                            intptr_t index_scale,
+                                            bool* needs_base) {
+  if (!IsSafeSmi(constant)) {
+    return false;
+  }
+  const int64_t index = target::SmiValue(constant);
+  const intptr_t offset_base =
+      (is_external ? 0
+                   : (target::Instance::DataOffsetFor(cid) - kHeapObjectTag));
+  const int64_t offset = index * index_scale + offset_base;
+  if (!Utils::IsInt(32, offset)) {
+    return false;
+  }
+  return Address::CanHoldOffset(static_cast<int32_t>(offset));
+}
+
 void Assembler::Bind(Label* label) {
   ASSERT(!label->IsBound());
   intptr_t bound_pc = buffer_.Size();

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -1429,6 +1429,13 @@ class Assembler : public AssemblerBase {
   // the branch delay slot.
   void LeaveStubFrameAndReturn(Register ra = RA);
 
+  // Set up a frame for calling a C function.
+  // Automatically save the pinned registers in Dart which are not callee-
+  // saved in the native calling convention.
+  // Use together with CallCFunction.
+  void EnterCFrame(intptr_t frame_space);
+  void LeaveCFrame();
+
   // Set up a Dart frame on entry with a frame pointer and PC information to
   // enable easy access to the RawInstruction object of code corresponding
   // to this frame.

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -947,11 +947,25 @@ class Assembler : public AssemblerBase {
   }
 
   void BranchUnsignedGreaterEqual(Register rd, Register rs, Label* l) {
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    sltu(CMPRES2, rd, rs);  // CMPRES2 = rd < rs ? 1 : 0.
+    beq(CMPRES2, ZR, l);
   }
 
   void BranchUnsignedGreaterEqual(Register rd, const Immediate& imm, Label* l) {
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    if (imm.value() == 0) {
+      b(l);
+    } else {
+      if (Utils::IsInt(kImmBits, imm.value())) {
+        sltiu(CMPRES2, rd, imm);
+        beq(CMPRES2, ZR, l);
+      } else {
+        ASSERT(rd != CMPRES2);
+        LoadImmediate(CMPRES2, imm.value());
+        BranchUnsignedGreaterEqual(rd, CMPRES2, l);
+      }
+    }
   }
 
   void BranchSignedLess(Register rd, Register rs, Label* l) {

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -1360,6 +1360,9 @@ class Assembler : public AssemblerBase {
     UNREACHABLE();
   }
 
+  static int32_t EncodeBranchOffset(int32_t offset, int32_t inst);
+  static int32_t DecodeBranchOffset(int32_t inst);
+
   void AddBranchOverflow(Register rd,
                         Register rs1,
                         Register rs2,
@@ -1437,7 +1440,10 @@ class Assembler : public AssemblerBase {
          fs << kFsShift | fd << kFdShift | func << kCop1FnShift);
   }
 
+  void EmitFarJump(int32_t offset, bool link);
+  void EmitFarBranch(Opcode b, Register rs, Register rt, int32_t offset);
   void EmitBranch(Opcode b, Register rs, Register rt, Label* label);
+  void BailoutIfInvalidBranchOffset(int32_t offset);
   void EmitRegImmBranch(RtRegImm b, Register rs, Label* label);
   void EmitFpuBranch(bool kind, Label* label);
 

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -810,21 +810,41 @@ class Assembler : public AssemblerBase {
   }
 
   void OrImmediate(Register rd, Register rs, int32_t imm) {
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    if (imm == 0) {
+      mov(rd, rs);
+      return;
+    }
+
+    if (Utils::IsUint(kImmBits, imm)) {
+      ori(rd, rs, Immediate(imm));
+    } else {
+      LoadImmediate(TMP, imm);
+      or_(rd, rs, TMP);
+    }
   }
 
   void OrImmediate(Register rd, int32_t imm) {
-    UNIMPLEMENTED();
+    OrImmediate(rd, rd, imm);
   }
 
   void AndRegisters(Register dst,
                     Register src1,
-                    Register src2 = kNoRegister) override{
-    UNIMPLEMENTED();
-  }
+                    Register src2 = kNoRegister) override;
 
   void XorImmediate(Register rd, Register rs, int32_t imm) {
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    if (imm == 0) {
+      mov(rd, rs);
+      return;
+    }
+
+    if (Utils::IsUint(kImmBits, imm)) {
+      xori(rd, rs, Immediate(imm));
+    } else {
+      LoadImmediate(TMP, imm);
+      xor_(rd, rs, TMP);
+    }
   }
 
   void LslImmediate(Register rd,

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -1260,6 +1260,7 @@ class Assembler : public AssemblerBase {
   void Load(Register dest, const Address& address, OperandSize sz = kWordBytes) override;
 
   void LoadSImmediate(DRegister reg, float imms);
+  void LoadDImmediate(DRegister reg, double immd, Register scratch);
 
   void LoadIndexedPayload(Register dst,
                           Register base,

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -1442,6 +1442,7 @@ class Assembler : public AssemblerBase {
 
   void EmitFarJump(int32_t offset, bool link);
   void EmitFarBranch(Opcode b, Register rs, Register rt, int32_t offset);
+  void EmitFarRegImmBranch(RtRegImm b, Register rs, int32_t offset);
   void EmitBranch(Opcode b, Register rs, Register rt, Label* label);
   void BailoutIfInvalidBranchOffset(int32_t offset);
   void EmitRegImmBranch(RtRegImm b, Register rs, Label* label);

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -843,11 +843,21 @@ class Assembler : public AssemblerBase {
   void BranchEqual(Register rd, Register rn, Label* l) { beq(rd, rn, l); }
 
   void BranchEqual(Register rd, const Immediate& imm, Label* l) {
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    if (imm.value() == 0) {
+      beq(rd, ZR, l);
+    } else {
+      ASSERT(rd != CMPRES2);
+      LoadImmediate(CMPRES2, imm.value());
+      beq(rd, CMPRES2, l);
+    }
   }
 
   void BranchEqual(Register rd, const Object& object, Label* l) {
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    ASSERT(rd != CMPRES2);
+    LoadObject(CMPRES2, object);
+    beq(rd, CMPRES2, l);
   }
 
   void BranchNotEqual(Register rd, Register rn, Label* l) { bne(rd, rn, l); }

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -1032,11 +1032,24 @@ class Assembler : public AssemblerBase {
   }
 
   void BranchUnsignedLessEqual(Register rd, Register rs, Label* l) {
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    BranchUnsignedGreaterEqual(rs, rd, l);
   }
 
   void BranchUnsignedLessEqual(Register rd, const Immediate& imm, Label* l) {
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    if (imm.value() == 0) {
+      beq(rd, ZR, l);
+    } else {
+      if ((imm.value() != -1) && Utils::IsInt(kImmBits, imm.value() + 1)) {
+        sltiu(CMPRES2, rd, Immediate(imm.value() + 1));
+        bne(CMPRES2, ZR, l);
+      } else {
+        ASSERT(rd != CMPRES2);
+        LoadImmediate(CMPRES2, imm.value());
+        BranchUnsignedGreaterEqual(CMPRES2, rd, l);
+      }
+    }
   }
 
   Register LoadConditionOperand(Register rd,

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -1042,6 +1042,7 @@ class Assembler : public AssemblerBase {
 
   void LoadClassId(Register result, Register object);
   void LoadClassById(Register result, Register class_id);
+  void LoadClass(Register result, Register object);
   void CompareClassId(Register object,
                     intptr_t class_id,
                     Register scratch = kNoRegister);

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -903,11 +903,25 @@ class Assembler : public AssemblerBase {
   }
 
   void BranchUnsignedGreater(Register rd, Register rs, Label* l) {
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    sltu(CMPRES2, rs, rd);
+    bne(CMPRES2, ZR, l);
   }
 
   void BranchUnsignedGreater(Register rd, const Immediate& imm, Label* l) {
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    if (imm.value() == 0) {
+      BranchNotEqual(rd, Immediate(0), l);
+    } else {
+      if ((imm.value() != -1) && Utils::IsInt(kImmBits, imm.value() + 1)) {
+        sltiu(CMPRES2, rd, Immediate(imm.value() + 1));
+        beq(CMPRES2, ZR, l);
+      } else {
+        ASSERT(rd != CMPRES2);
+        LoadImmediate(CMPRES2, imm.value());
+        BranchUnsignedGreater(rd, CMPRES2, l);
+      }
+    }
   }
 
   void BranchSignedGreaterEqual(Register rd, Register rs, Label* l) {

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -925,11 +925,25 @@ class Assembler : public AssemblerBase {
   }
 
   void BranchSignedGreaterEqual(Register rd, Register rs, Label* l) {
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    slt(CMPRES2, rd, rs);  // CMPRES2 = rd < rs ? 1 : 0.
+    beq(CMPRES2, ZR, l);   // If CMPRES2 = 0, then rd >= rs.
   }
 
   void BranchSignedGreaterEqual(Register rd, const Immediate& imm, Label* l) {
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    if (imm.value() == 0) {
+      bgez(rd, l);
+    } else {
+      if (Utils::IsInt(kImmBits, imm.value())) {
+        slti(CMPRES2, rd, imm);
+        beq(CMPRES2, ZR, l);
+      } else {
+        ASSERT(rd != CMPRES2);
+        LoadImmediate(CMPRES2, imm.value());
+        BranchSignedGreaterEqual(rd, CMPRES2, l);
+      }
+    }
   }
 
   void BranchUnsignedGreaterEqual(Register rd, Register rs, Label* l) {

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -767,11 +767,20 @@ class Assembler : public AssemblerBase {
   }
 
   void AddImmediate(Register rd, Register rs, int32_t value) {
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    if ((value == 0) && (rd == rs)) return;
+    // If value is 0, we still want to move rs to rd if they aren't the same.
+    if (Utils::IsInt(kImmBits, value)) {
+      addiu(rd, rs, Immediate(value));
+    } else {
+      LoadImmediate(TMP, value);
+      addu(rd, rs, TMP);
+    }
   }
 
   void AddImmediate(Register rd, int32_t value) {
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    AddImmediate(rd, rd, value);
   }
 
   void AddRegisters(Register rd, Register rs) { addu(rd, rd, rs); }

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -721,15 +721,49 @@ class Assembler : public AssemblerBase {
   void RestoreCodePointer();
 
   void LoadImmediate(Register rd, int32_t value) override{
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    if (Utils::IsInt(kImmBits, value)) {
+      addiu(rd, ZR, Immediate(value));
+    } else {
+      const uint16_t low = Utils::Low16Bits(value);
+      const uint16_t high = Utils::High16Bits(value);
+      lui(rd, Immediate(high));
+      if (low != 0) {
+        ori(rd, rd, Immediate(low));
+      }
+    }
   }
 
   void LoadImmediate(DRegister rd, double value) {
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    FRegister frd = static_cast<FRegister>(rd * 2);
+    const int64_t ival = bit_cast<uint64_t, double>(value);
+    const int32_t low = Utils::Low32Bits(ival);
+    const int32_t high = Utils::High32Bits(ival);
+    if (low != 0) {
+      LoadImmediate(TMP, low);
+      mtc1(TMP, frd);
+    } else {
+      mtc1(ZR, frd);
+    }
+
+    if (high != 0) {
+      LoadImmediate(TMP, high);
+      mtc1(TMP, static_cast<FRegister>(frd + 1));
+    } else {
+      mtc1(ZR, static_cast<FRegister>(frd + 1));
+    }
   }
 
   void LoadImmediate(FRegister rd, float value) {
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    const int32_t ival = bit_cast<int32_t, float>(value);
+    if (ival == 0) {
+      mtc1(ZR, rd);
+    } else {
+      LoadImmediate(TMP, ival);
+      mtc1(TMP, rd);
+    }
   }
 
   void AddImmediate(Register rd, Register rs, int32_t value) {

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -789,13 +789,24 @@ class Assembler : public AssemblerBase {
                     Register rs,
                     target::word imm,
                     OperandSize sz = kWordBytes) override {
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    if (imm == 0) {
+      mov(rd, ZR);
+      return;
+    }
+
+    if (Utils::IsUint(kImmBits, imm)) {
+      andi(rd, rs, Immediate(imm));
+    } else {
+      LoadImmediate(TMP, imm);
+      and_(rd, rs, TMP);
+    }
   }
 
   void AndImmediate(Register reg,
                     target::word imm,
                     OperandSize sz = kWordBytes) override {
-    UNIMPLEMENTED();
+    AndImmediate(reg, reg, imm, sz);
   }
 
   void OrImmediate(Register rd, Register rs, int32_t imm) {

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -1011,11 +1011,24 @@ class Assembler : public AssemblerBase {
   }
 
   void BranchSignedLessEqual(Register rd, Register rs, Label* l) {
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    BranchSignedGreaterEqual(rs, rd, l);
   }
 
   void BranchSignedLessEqual(Register rd, const Immediate& imm, Label* l) {
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    if (imm.value() == 0) {
+      blez(rd, l);
+    } else {
+      if (Utils::IsInt(kImmBits, imm.value() + 1)) {
+        slti(CMPRES2, rd, Immediate(imm.value() + 1));
+        bne(CMPRES2, ZR, l);
+      } else {
+        ASSERT(rd != CMPRES2);
+        LoadImmediate(CMPRES2, imm.value());
+        BranchSignedGreaterEqual(CMPRES2, rd, l);
+      }
+    }
   }
 
   void BranchUnsignedLessEqual(Register rd, Register rs, Label* l) {

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -881,11 +881,25 @@ class Assembler : public AssemblerBase {
   }
 
   void BranchSignedGreater(Register rd, Register rs, Label* l) {
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    slt(CMPRES2, rs, rd);  // CMPRES2 = rd > rs ? 1 : 0.
+    bne(CMPRES2, ZR, l);
   }
 
   void BranchSignedGreater(Register rd, const Immediate& imm, Label* l) {
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    if (imm.value() == 0) {
+      bgtz(rd, l);
+    } else {
+      if (Utils::IsInt(kImmBits, imm.value() + 1)) {
+        slti(CMPRES2, rd, Immediate(imm.value() + 1));
+        beq(CMPRES2, ZR, l);
+      } else {
+        ASSERT(rd != CMPRES2);
+        LoadImmediate(CMPRES2, imm.value());
+        BranchSignedGreater(rd, CMPRES2, l);
+      }
+    }
   }
 
   void BranchUnsignedGreater(Register rd, Register rs, Label* l) {

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -1501,6 +1501,12 @@ class Assembler : public AssemblerBase {
                               Register scratch,
                               bool is_shared);
 
+  void LoadHalfWordUnaligned(Register dst, Register addr, Register tmp);
+  void LoadHalfWordUnsignedUnaligned(Register dst, Register addr, Register tmp);
+  void StoreHalfWordUnaligned(Register src, Register addr, Register tmp);
+  void LoadWordUnaligned(Register dst, Register addr, Register tmp);
+  void StoreWordUnaligned(Register src, Register addr, Register tmp);
+
   void MaybeTraceAllocation(intptr_t cid,
                             Label* trace,
                             Register temp_reg,

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -1455,6 +1455,33 @@ class Assembler : public AssemblerBase {
   // up on entry (it is the frame of the unoptimized code).
   void EnterOsrFrame(intptr_t extra_size);
 
+  Address ElementAddressForIntIndex(bool is_external,
+                                    intptr_t cid,
+                                    intptr_t index_scale,
+                                    Register array,
+                                    intptr_t index) const;
+  void LoadElementAddressForIntIndex(Register address,
+                                     bool is_external,
+                                     intptr_t cid,
+                                     intptr_t index_scale,
+                                     Register array,
+                                     intptr_t index);
+  Address ElementAddressForRegIndex(bool is_load,
+                                    bool is_external,
+                                    intptr_t cid,
+                                    intptr_t index_scale,
+                                    bool index_unboxed,
+                                    Register array,
+                                    Register index);
+  void LoadElementAddressForRegIndex(Register address,
+                                     bool is_load,
+                                     bool is_external,
+                                     intptr_t cid,
+                                     intptr_t index_scale,
+                                     bool index_unboxed,
+                                     Register array,
+                                     Register index);
+
   void EnterFullSafepoint(Register scratch0, Register scratch1);
   void ExitFullSafepoint(Register scratch0,
                          Register scratch1);

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -1259,6 +1259,8 @@ class Assembler : public AssemblerBase {
 
   void Load(Register dest, const Address& address, OperandSize sz = kWordBytes) override;
 
+  void LoadSImmediate(DRegister reg, float imms);
+
   void LoadIndexedPayload(Register dst,
                           Register base,
                           int32_t offset,
@@ -1298,6 +1300,12 @@ class Assembler : public AssemblerBase {
     FRegister hi = static_cast<FRegister>(reg * 2 + 1);
     lwc1(lo, PrepareLargeOffset(base, offset));
     lwc1(hi, PrepareLargeOffset(base, offset + target::kWordSize));
+  }
+
+  void LoadSFromOffset(DRegister reg, Register base, int32_t offset) {
+    ASSERT(!in_delay_slot_);
+    FRegister freg = static_cast<FRegister>(reg * 2);
+    lwc1(freg, PrepareLargeOffset(base, offset));
   }
 
   void StoreDToOffset(DRegister reg, Register base, int32_t offset) {

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -1538,6 +1538,10 @@ class Assembler : public AssemblerBase {
   // Requires a scratch register in addition to the assembler temporary.
   void EmitEntryFrameVerification(Register scratch);
 
+  void LoadNativeEntry(Register rd,
+                       const ExternalLabel* label,
+                       ObjectPoolBuilderEntry::Patchability patchable);
+
   void PushObject(const Object& object);
 
   void CompareObject(Register reg, const Object& object);

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -969,11 +969,24 @@ class Assembler : public AssemblerBase {
   }
 
   void BranchSignedLess(Register rd, Register rs, Label* l) {
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    BranchSignedGreater(rs, rd, l);
   }
 
   void BranchSignedLess(Register rd, const Immediate& imm, Label* l) {
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    if (imm.value() == 0) {
+      bltz(rd, l);
+    } else {
+      if (Utils::IsInt(kImmBits, imm.value())) {
+        slti(CMPRES2, rd, imm);
+        bne(CMPRES2, ZR, l);
+      } else {
+        ASSERT(rd != CMPRES2);
+        LoadImmediate(CMPRES2, imm.value());
+        BranchSignedGreater(CMPRES2, rd, l);
+      }
+    }
   }
 
   void BranchUnsignedLess(Register rd, Register rs, Label* l) {

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -156,6 +156,12 @@ class Assembler : public AssemblerBase {
     addiu(SP, SP, Immediate(target::kWordSize));
   }
 
+  // Push all registers which are callee-saved according to the ARM ABI.
+  void PushNativeCalleeSavedRegisters();
+
+  // Pop all registers which are callee-saved according to the ARM ABI.
+  void PopNativeCalleeSavedRegisters();
+
   void Ret() { jr(RA); }
 
   void SetReturnAddress(Register value) { mov(RA, value); }

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -990,11 +990,24 @@ class Assembler : public AssemblerBase {
   }
 
   void BranchUnsignedLess(Register rd, Register rs, Label* l) {
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    BranchUnsignedGreater(rs, rd, l);
   }
 
   void BranchUnsignedLess(Register rd, const Immediate& imm, Label* l) {
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    if (imm.value() == 0) {
+      // Never branch. Fall through.
+    } else {
+      if (Utils::IsInt(kImmBits, imm.value())) {
+        sltiu(CMPRES2, rd, imm);
+        bne(CMPRES2, ZR, l);
+      } else {
+        ASSERT(rd != CMPRES2);
+        LoadImmediate(CMPRES2, imm.value());
+        BranchUnsignedGreater(CMPRES2, rd, l);
+      }
+    }
   }
 
   void BranchSignedLessEqual(Register rd, Register rs, Label* l) {

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -1443,6 +1443,7 @@ class Assembler : public AssemblerBase {
   void EmitFarJump(int32_t offset, bool link);
   void EmitFarBranch(Opcode b, Register rs, Register rt, int32_t offset);
   void EmitFarRegImmBranch(RtRegImm b, Register rs, int32_t offset);
+  void EmitFarFpuBranch(bool kind, int32_t offset);
   void EmitBranch(Opcode b, Register rs, Register rt, Label* label);
   void BailoutIfInvalidBranchOffset(int32_t offset);
   void EmitRegImmBranch(RtRegImm b, Register rs, Label* label);

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -1632,7 +1632,19 @@ class Assembler : public AssemblerBase {
   static int32_t EncodeBranchOffset(int32_t offset, int32_t inst);
   static int32_t DecodeBranchOffset(int32_t inst);
 
+  void AddImmediateBranchOverflow(Register rd,
+                                  Register rs1,
+                                  int32_t imm,
+                                  Label* overflow);
+  void SubtractImmediateBranchOverflow(Register rd,
+                                       Register rs1,
+                                       int32_t imm,
+                                       Label* overflow);
   void AddBranchOverflow(Register rd,
+                        Register rs1,
+                        Register rs2,
+                        Label* overflow);
+  void SubtractBranchOverflow(Register rd,
                         Register rs1,
                         Register rs2,
                         Label* overflow);

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -1562,6 +1562,13 @@ class Assembler : public AssemblerBase {
   void ExtractClassIdFromTags(Register result, Register tags);
   void ExtractInstanceSizeFromTags(Register result, Register tags);
 
+  static bool AddressCanHoldConstantIndex(const Object& constant,
+                                          bool is_load,
+                                          bool is_external,
+                                          intptr_t cid,
+                                          intptr_t index_scale,
+                                          bool* needs_base = nullptr);
+
   void LoadUnboxedDouble(FpuRegister dst, Register base, int32_t offset) {
     LoadDFromOffset(dst, base, offset);
   }

--- a/runtime/vm/compiler/assembler/assembler_mips.h
+++ b/runtime/vm/compiler/assembler/assembler_mips.h
@@ -863,11 +863,21 @@ class Assembler : public AssemblerBase {
   void BranchNotEqual(Register rd, Register rn, Label* l) { bne(rd, rn, l); }
 
   void BranchNotEqual(Register rd, const Immediate& imm, Label* l) {
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    if (imm.value() == 0) {
+      bne(rd, ZR, l);
+    } else {
+      ASSERT(rd != CMPRES2);
+      LoadImmediate(CMPRES2, imm.value());
+      bne(rd, CMPRES2, l);
+    }
   }
 
   void BranchNotEqual(Register rd, const Object& object, Label* l) {
-    UNIMPLEMENTED();
+    ASSERT(!in_delay_slot_);
+    ASSERT(rd != CMPRES2);
+    LoadObject(CMPRES2, object);
+    bne(rd, CMPRES2, l);
   }
 
   void BranchSignedGreater(Register rd, Register rs, Label* l) {


### PR DESCRIPTION
This PR implements assembler helper functions for the MIPS32 backend:

Branch emission:

- EmitBranch, EmitRegImmBranch, EmitFpuBranch
- EmitFarJump, EmitFarBranch, EmitFarRegImmBranch, EmitFarFpuBranch
- EncodeBranchOffset, DecodeBranchOffset
- BailoutIfInvalidBranchOffset
- PatchFarJump

Label binding:

- Bind
- FlipBranchInstruction

Class inspection:

- LoadClassId, LoadClassById, LoadClass, CompareClassId

Comparison branch helpers:

- BranchEqual, BranchNotEqual
- BranchSignedGreater, BranchUnsignedGreater
- BranchSignedGreaterEqual, BranchUnsignedGreaterEqual
- BranchSignedLess, BranchUnsignedLess
- BranchSignedLessEqual, BranchUnsignedLessEqual

Immediate arithmetic and logic:

- LoadImmediate (integer, double, float)
- AddImmediate
- AndImmediate
- OrImmediate, XorImmediate

FPU immediate loads:

- LoadSImmediate, LoadSFromOffset
- LoadDImmediate

Object pool and native entries:

- LoadNativeEntry

C frame management:

- EnterCFrame, LeaveCFrame
- PushNativeCalleeSavedRegisters, PopNativeCalleeSavedRegisters

Array indexing:

- AddressCanHoldConstantIndex
- ElementAddressForIntIndex, ElementAddressForRegIndex
- LoadElementAddressForIntIndex, LoadElementAddressForRegIndex

Unaligned memory access:

- LoadHalfWordUnaligned, LoadHalfWordUnsignedUnaligned
- StoreHalfWordUnaligned
- LoadWordUnaligned, StoreWordUnaligned

Overflow-checked arithmetic:

- SubtractBranchOverflow
- AddImmediateBranchOverflow, SubtractImmediateBranchOverflow