### PR TITLE
[mips] Add Clang build support for Dart

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -19,6 +19,9 @@ import("//build/config/android/config.gni")
 if (current_cpu == "arm") {
   import("//build/config/arm.gni")
 }
+if (current_cpu == "mipsel") {
+  import("//build/config/mips.gni")
+}
 if (is_win) {
   import("//build/config/win/visual_studio_version.gni")
 }
@@ -295,6 +298,58 @@ config("compiler") {
       if (arm_tune != "") {
         cflags += [ "-mtune=$arm_tune" ]
       }
+    } else if (current_cpu == "mipsel") {
+      # Some toolchains default to big-endian.
+      cflags += [ "-EL" ]
+      ldflags += [ "-EL" ]
+      if(is_clang){
+        cflags += ["-march=mipsel"]
+      }
+      # We have to explicitly request exceptions to get good heap profiles from
+      # tcmalloc.
+      if (is_debug || is_release) {
+        cflags += [
+          "-fexceptions",
+          "-funwind-tables",
+        ]
+      }
+
+      if (mips_arch_variant == "r6") {
+        cflags += [
+          "-mips32r6",
+          "-Wa,-mips32r6",
+        ]
+        if (is_android) {
+          ldflags += [
+            "-mips32r6",
+            "-Wl,-melf32ltsmip",
+          ]
+        }
+      } else if (mips_arch_variant == "r2") {
+        cflags += [
+          "-mips32r2",
+          "-Wa,-mips32r2",
+        ]
+        if (mips_float_abi == "hard" && mips_fpu_mode != "") {
+          cflags += [ "-m$mips_fpu_mode" ]
+        }
+      } else if (mips_arch_variant == "r1") {
+        cflags += [
+          "-mips32",
+          "-Wa,-mips32",
+        ]
+        if (mips_float_abi == "hard" && mips_fpu_mode != "") {
+          cflags += [ "-m$mips_fpu_mode" ]
+        }
+      }
+
+      if (mips_dsp_rev == 1) {
+        cflags += [ "-mdsp" ]
+      } else if (mips_dsp_rev == 2) {
+        cflags += [ "-mdspr2" ]
+      }
+
+      cflags += [ "-m${mips_float_abi}-float" ]
     }
   }
 
@@ -364,6 +419,9 @@ config("compiler") {
         } else if (current_cpu == "x86") {
           cflags += [ "--target=i386-linux-gnu" ]
           ldflags += [ "--target=i386-linux-gnu" ]
+        } else if (current_cpu == "mipsel") {
+          cflags += [ "--target=mipsel-linux-gnu" ]
+          ldflags += [ "--target=mipsel-linux-gnu" ]
         }
       }
     }
@@ -437,6 +495,9 @@ config("compiler") {
       } else if (current_cpu == "riscv64") {
         cflags += [ "--target=riscv64-linux-android${android_api_level}" ]
         ldflags += [ "--target=riscv64-linux-android${android_api_level}" ]
+      } else if (current_cpu == "mipsel") {
+        cflags += [ "--target=mipsel-linux-android${android_api_level}" ]
+        ldflags += [ "--target=mipsel-linux-android${android_api_level}" ]
       }
     }
   }
@@ -904,7 +965,8 @@ if (is_win) {
     }
   }
 
-  if (is_clang && !using_sanitizer) {
+  # MIPS uses GNU ld instead of lld/gold, so --icf=all must be disabled.
+  if (is_clang && !using_sanitizer && current_cpu != "mipsel") {
     # Identical code folding to reduce size.
     # Warning: This changes C/C++ semantics of function pointer comparison.
     # Needs lld/gold/mold instead of GNU ld/Mac ld.

--- a/build/config/linux/BUILD.gn
+++ b/build/config/linux/BUILD.gn
@@ -23,8 +23,11 @@ config("sdk") {
   }
 
   if (sysroot != "") {
-    cflags += [ "--sysroot=" + sysroot ]
-    ldflags += [ "--sysroot=" + sysroot ]
+
+    if(!(target_cpu == "mipsel" && is_clang)) {
+      cflags += [ "--sysroot=" + sysroot ]
+      ldflags += [ "--sysroot=" + sysroot ]
+    }
 
     # Need to get some linker flags out of the sysroot.
     ldflags += [ exec_script("sysroot_ld_path.py",

--- a/build/config/mips.gni
+++ b/build/config/mips.gni
@@ -1,0 +1,31 @@
+# Copyright 2026 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+if (current_cpu == "mipsel") {
+  declare_args() {
+    # MIPS arch variant. Possible values are:
+    #   "r1"
+    #   "r2"
+    #   "r6"
+    mips_arch_variant = "r1"
+
+    # MIPS DSP ASE revision. Possible values are:
+    #   0: unavailable
+    #   1: revision 1
+    #   2: revision 2
+    mips_dsp_rev = 0
+
+    # MIPS floating-point ABI. Possible values are:
+    #   "hard": sets the GCC -mhard-float option.
+    #   "soft": sets the GCC -msoft-float option.
+    mips_float_abi = "hard"
+
+    # MIPS32 floating-point register width. Possible values are:
+    #   "fp32": sets the GCC -mfp32 option.
+    #   "fp64": sets the GCC -mfp64 option.
+    #   "fpxx": sets the GCC -mfpxx option.
+    mips_fpu_mode = "fp32"
+  }
+}
+

--- a/build/toolchain/gcc_toolchain.gni
+++ b/build/toolchain/gcc_toolchain.gni
@@ -98,9 +98,20 @@ template("gcc_toolchain") {
     lib_switch = "-l"
     lib_dir_switch = "-L"
 
+    additional_for_mipsel_clang_compilation = ""
+    if(target_name == "clang_mipsel"){
+      mipsel_sysroot = invoker.sysroot
+      mipsel_include_dirs = "-isystem$mipsel_sysroot/../include/c++/13.3.0"
+      mipsel_include_dirs += " -isystem$mipsel_sysroot/../include/c++/13.3.0/mipsel-buildroot-linux-gnu"
+
+      additional_for_mipsel_clang_compilation = mipsel_include_dirs + " --sysroot=" + mipsel_sysroot
+    } else if (target_name == "clang_x86" && target_cpu == "mipsel"){
+      additional_for_mipsel_clang_compilation = "--sysroot=" + "../../buildtools/sysroot/linux"
+    }
+
     tool("cc") {
       depfile = "{{output}}.d"
-      command = "$cc -MMD -MF $depfile {{defines}} {{include_dirs}} {{cflags}} {{cflags_c}} -c {{source}} -o {{output}}"
+      command = "$cc -MMD -MF $depfile {{defines}} {{include_dirs}} {{cflags}} {{cflags_c}} $additional_for_mipsel_clang_compilation -c {{source}} -o {{output}}"
       depsformat = "gcc"
       description = "CC {{output}}"
       outputs =
@@ -109,7 +120,7 @@ template("gcc_toolchain") {
 
     tool("cxx") {
       depfile = "{{output}}.d"
-      command = "$cxx -MMD -MF $depfile {{defines}} {{include_dirs}} {{cflags}} {{cflags_cc}} -c {{source}} -o {{output}}"
+      command = "$cxx -MMD -MF $depfile {{defines}} {{include_dirs}} {{cflags}} {{cflags_cc}} $additional_for_mipsel_clang_compilation -c {{source}} -o {{output}}"
       depsformat = "gcc"
       description = "CXX {{output}}"
       outputs =
@@ -119,7 +130,7 @@ template("gcc_toolchain") {
     tool("asm") {
       # For GCC we can just use the C compiler to compile assembly.
       depfile = "{{output}}.d"
-      command = "$asm -MMD -MF $depfile {{defines}} {{include_dirs}} {{asmflags}} -c {{source}} -o {{output}}"
+      command = "$asm -MMD -MF $depfile {{defines}} {{include_dirs}} {{asmflags}} $additional_for_mipsel_clang_compilation -c {{source}} -o {{output}}"
       depsformat = "gcc"
       description = "ASM {{output}}"
       outputs =
@@ -148,8 +159,23 @@ template("gcc_toolchain") {
       # existing .TOC file, overwrite it, otherwise, don't change it.
       tocfile = sofile + ".TOC"
       temporary_tocname = sofile + ".tmp"
+
+      additional_for_mipsel_clang_linking = ""
+      additional_for_mipsel_clang_linking_end = ""
+      if(target_name == "clang_mipsel"){
+        mipsel_sysroot  = invoker.sysroot
+        mipsel_lib_dirs = " -L$mipsel_sysroot/../../lib/gcc/mipsel-buildroot-linux-gnu/13.3.0"
+        mipsel_ld = "$mipsel_sysroot/../../bin/mipsel-buildroot-linux-gnu-ld"
+
+        additional_for_mipsel_clang_linking = "-fuse-ld=$mipsel_ld "
+        additional_for_mipsel_clang_linking += mipsel_lib_dirs + " --sysroot=" + mipsel_sysroot
+        additional_for_mipsel_clang_linking_end += " -latomic"
+      } else if (target_name == "clang_x86" && target_cpu == "mipsel"){
+        additional_for_mipsel_clang_linking = "--sysroot=" + "../../buildtools/sysroot/linux"
+      }
+
       link_command =
-          "$ld -shared {{ldflags}} -o $sofile -Wl,-soname=$soname @$rspfile"
+          "$ld -shared {{ldflags}} $additional_for_mipsel_clang_linking -o $sofile -Wl,-soname=$soname @$rspfile $additional_for_mipsel_clang_linking_end"
       toc_command = "{ $readelf -d $sofile | grep SONAME ; $nm -gD -f posix $sofile | cut -f1-2 -d' '; } > $temporary_tocname"
       replace_command = "if ! cmp -s $temporary_tocname $tocfile; then mv $temporary_tocname $tocfile; fi"
 
@@ -199,7 +225,21 @@ template("gcc_toolchain") {
         stripped_outfile = "{{root_out_dir}}/exe.stripped/$exename"
       }
 
-      command = "$ld {{ldflags}} -o $outfile -Wl,--start-group @$rspfile {{solibs}} -Wl,--end-group $libs_section_prefix {{libs}} $libs_section_postfix"
+      additional_for_mipsel_clang_linking = ""
+      additional_for_mipsel_clang_linking_end = ""
+      if(target_name == "clang_mipsel"){
+        mipsel_sysroot  = invoker.sysroot
+        mipsel_lib_dirs = " -L$mipsel_sysroot/../../lib/gcc/mipsel-buildroot-linux-gnu/13.3.0"
+        mipsel_ld = "$mipsel_sysroot/../../bin/mipsel-buildroot-linux-gnu-ld"
+
+        additional_for_mipsel_clang_linking = "-fuse-ld=$mipsel_ld "
+        additional_for_mipsel_clang_linking += mipsel_lib_dirs + " --sysroot=" + mipsel_sysroot
+        additional_for_mipsel_clang_linking_end += " -latomic"
+      } else if (target_name == "clang_x86" && target_cpu == "mipsel"){
+        additional_for_mipsel_clang_linking = "--sysroot=" + "../../buildtools/sysroot/linux"
+      }
+
+      command = "$ld {{ldflags}} $additional_for_mipsel_clang_linking -o $outfile -Wl,--start-group @$rspfile {{solibs}}  -Wl,--end-group $libs_section_prefix {{libs}} $libs_section_postfix $additional_for_mipsel_clang_linking_end"
 
       symbolizer_script =
           rebase_path("//runtime/tools/dart_profiler_symbols.py")

--- a/build/toolchain/linux/BUILD.gn
+++ b/build/toolchain/linux/BUILD.gn
@@ -338,3 +338,27 @@ gcc_toolchain_suite("mipsel") {
   is_clang = false
 }
 
+gcc_toolchain_suite("clang_mipsel") {
+  prefix = rebased_clang_dir
+  if (mips_toolchain_prefix != "") {
+    prefix = mips_toolchain_prefix
+  }
+  cc = "${compiler_prefix}${prefix}/clang"
+  cxx = "${compiler_prefix}${prefix}/clang++"
+  asm = "${assembler_prefix}${prefix}/clang"
+
+  if (use_rbe) {
+    cc = "${cc} --target=mipsel-linux-gnu-"
+    cxx = "${cxx} --target=mipsel-linux-gnu-"
+  }
+
+  readelf = "${prefix}/llvm-readelf"
+  nm = "${prefix}/llvm-nm"
+  ar = "${prefix}/llvm-ar"
+  ld = "${link_prefix}${prefix}/clang++"
+  llvm_objcopy = "${prefix}/llvm-objcopy"
+
+  toolchain_cpu = "mipsel"
+  toolchain_os = "linux"
+  is_clang = true
+}


### PR DESCRIPTION
This PR adds support for building the Dart SDK for MIPS using Clang.

It introduces a new clang_mipsel toolchain, updates compiler and linker
flags for MIPS, and adjusts sysroot and include handling to ensure
successful cross-compilation.