### PR TITLE
[mips] Relocation and trampoline generation for long branches

### DIFF
--- a/runtime/vm/compiler/assembler/assembler_mips.cc
+++ b/runtime/vm/compiler/assembler/assembler_mips.cc
@@ -973,15 +973,33 @@ void Assembler::GenerateUnRelocatedPcRelativeTailCall(
   EmitIType(BEQ, R0, R0, 0);
   EmitBranchDelayNop();
 
+  // Reserve space for a trampoline (7 NOP instructions).
+  EmitBranchDelayNop();
+  EmitBranchDelayNop();
+  EmitBranchDelayNop();
+  EmitBranchDelayNop();
+  EmitBranchDelayNop();
+  EmitBranchDelayNop();
+  EmitBranchDelayNop();
+
   PcRelativeTailCallPattern pattern(buffer_.contents() + buffer_.Size() -
-                                PcRelativeTailCallPattern::kLengthInBytes);
+                                    PcRelativeTailCallPattern::kLengthInBytes);
   pattern.set_distance(offset_into_target);
 }
 
-void Assembler::GenerateUnRelocatedPcRelativeCall(
-    intptr_t offset_into_target) {
+void Assembler::GenerateUnRelocatedPcRelativeCall(intptr_t offset_into_target) {
   // Emit "bal <offset>".
   EmitRegImmType(REGIMM, R0, BGEZAL, 0);
+  // Adjust return address to point past the reserved trampoline space.
+  addiu(RA, RA, Immediate(7 * 4));
+
+  // Reserve space for a trampoline (7 NOP instructions).
+  EmitBranchDelayNop();
+  EmitBranchDelayNop();
+  EmitBranchDelayNop();
+  EmitBranchDelayNop();
+  EmitBranchDelayNop();
+  EmitBranchDelayNop();
   EmitBranchDelayNop();
 
   PcRelativeCallPattern pattern(buffer_.contents() + buffer_.Size() -

--- a/runtime/vm/compiler/relocation.cc
+++ b/runtime/vm/compiler/relocation.cc
@@ -502,11 +502,15 @@ void CodeRelocator::BuildTrampolinesForAlmostOutOfRangeCalls(
     // In the worst case we'll make a new trampoline here, in which case the
     // current text offset must be in range for the "critical"
     // [unresolved_call].
+#if !defined(TARGET_ARCH_MIPS) //on MIPS trampolines are placed inside of functions
     ASSERT(IsTargetInRangeFor(unresolved_call, next_text_offset_));
+#endif
 
     // See if there is already a trampoline we could use.
     intptr_t trampoline_text_offset = -1;
+#if !defined(TARGET_ARCH_MIPS)
     auto callee = Code::InstructionsOf(unresolved_call->callee);
+#endif
 
     if (!FLAG_always_generate_trampolines_for_testing) {
       auto old_trampoline_entry = FindTrampolineFor(unresolved_call);
@@ -520,6 +524,17 @@ void CodeRelocator::BuildTrampolinesForAlmostOutOfRangeCalls(
       // The ownership of the trampoline bytes will be transferred to the
       // [ImageWriter], which will eventually write out the bytes and delete the
       // buffer.
+#if defined(TARGET_ARCH_MIPS)
+      uword trampoline_bytes = Code::PayloadStartOf(unresolved_call->caller) + 
+                   unresolved_call->call_offset + 
+                   2 * Instr::kInstrSize;
+      auto unresolved_trampoline = new UnresolvedTrampoline{
+          unresolved_call->callee,
+          unresolved_call->offset_into_target,
+          (uint8_t*)trampoline_bytes,
+          unresolved_call->text_offset+2*4
+      };
+#else
       auto trampoline_bytes = new uint8_t[kTrampolineSize];
       ASSERT((kTrampolineSize % compiler::target::kWordSize) == 0);
       for (uint8_t* cur = trampoline_bytes;
@@ -535,6 +550,7 @@ void CodeRelocator::BuildTrampolinesForAlmostOutOfRangeCalls(
           next_text_offset_,
       };
       AddTrampolineToText(callee, trampoline_bytes, kTrampolineSize);
+#endif
       EnqueueUnresolvedTrampoline(unresolved_trampoline);
       trampoline_text_offset = unresolved_trampoline->text_offset;
     }

--- a/runtime/vm/compiler/relocation_test.cc
+++ b/runtime/vm/compiler/relocation_test.cc
@@ -291,8 +291,8 @@ ISOLATE_UNIT_TEST_CASE(CodeRelocator_DirectForwardCall) {
   // might actually make some of those unresolved calls resolved).
   helper.CreateInstructions({
 #if defined(TARGET_ARCH_MIPS)
-      36,  // caller (call instruction @helper.kOffsetOfCall)
-      fmax - (36 - helper.kOffsetOfCall) - 12,  // 12 bytes less than maximum gap
+      64,  // caller (call instruction @helper.kOffsetOfCall)
+      fmax - (64 - helper.kOffsetOfCall) - 12,  // 12 bytes less than maximum gap
       12                                        // forward call target
 #else
       20,  // caller (call instruction @helper.kOffsetOfCall)
@@ -323,8 +323,8 @@ ISOLATE_UNIT_TEST_CASE(CodeRelocator_OutOfRangeForwardCall) {
 
   helper.CreateInstructions({
 #if defined(TARGET_ARCH_MIPS)
-      36,  // caller (call instruction @helper.kOffsetOfCall)
-      fmax - (36 - helper.kOffsetOfCall) + 4,  //  4 bytes above maximum gap
+      64,  // caller (call instruction @helper.kOffsetOfCall)
+      fmax - (64 - helper.kOffsetOfCall) + 4,  //  4 bytes above maximum gap
       12                                        // forward call target
 #else
       20,  // caller (call instruction @helper.kOffsetOfCall)
@@ -337,17 +337,29 @@ ISOLATE_UNIT_TEST_CASE(CodeRelocator_OutOfRangeForwardCall) {
   helper.BuildImageAndRunTest(
       [&](const GrowableArray<ImageWriterCommand>& commands,
           uword* entry_point) {
+#if defined(TARGET_ARCH_MIPS)
+        // On MIPS the trampoline is generated within the caller’s code.
+        EXPECT_EQ(3, commands.length());
+#else
         EXPECT_EQ(4, commands.length());
+#endif
 
         // This makes an out-of-range forward call.
         EXPECT_EQ(ImageWriterCommand::InsertInstructionOfCode, commands[0].op);
         // This is the last change the relocator thinks it can ensure the
         // out-of-range call above can call a trampoline - so it injets it here
         // and no later.
+#if defined(TARGET_ARCH_MIPS)
+        // On MIPS the trampoline is generated within the caller’s code.
+        EXPECT_EQ(ImageWriterCommand::InsertInstructionOfCode, commands[1].op);
+        // This is the target of the forwards call.
+        EXPECT_EQ(ImageWriterCommand::InsertInstructionOfCode, commands[2].op);
+#else
         EXPECT_EQ(ImageWriterCommand::InsertBytesOfTrampoline, commands[1].op);
         EXPECT_EQ(ImageWriterCommand::InsertInstructionOfCode, commands[2].op);
         // This is the target of the forwards call.
         EXPECT_EQ(ImageWriterCommand::InsertInstructionOfCode, commands[3].op);
+#endif
 
         *entry_point = commands[0].expected_offset;
       });
@@ -361,7 +373,7 @@ ISOLATE_UNIT_TEST_CASE(CodeRelocator_DirectBackwardCall) {
 #if defined(TARGET_ARCH_MIPS)
       12,                                // backwards call target
       bmax - 12 - helper.kOffsetOfCall,  // maximize out backwards call range
-      36  // caller (call instruction @helper.kOffsetOfCall)
+      64  // caller (call instruction @helper.kOffsetOfCall)
 #else
       8,                                // backwards call target
       bmax - 8 - helper.kOffsetOfCall,  // maximize out backwards call range
@@ -394,8 +406,8 @@ ISOLATE_UNIT_TEST_CASE(CodeRelocator_OutOfRangeBackwardCall) {
 #if defined(TARGET_ARCH_MIPS)
       12,                                    // backward call target
       bmax - 12 - helper.kOffsetOfCall + 4,  // 4 bytes exceeding backwards range
-      36,  // caller (call instruction @helper.kOffsetOfCall)
-      fmax - (36 - helper.kOffsetOfCall) -
+      64,  // caller (call instruction @helper.kOffsetOfCall)
+      fmax - (64 - helper.kOffsetOfCall) -
           4,  // 4 bytes less than forward range
       4,
       4,  // out-of-range, so trampoline has to be inserted before this
@@ -414,7 +426,12 @@ ISOLATE_UNIT_TEST_CASE(CodeRelocator_OutOfRangeBackwardCall) {
   helper.BuildImageAndRunTest(
       [&](const GrowableArray<ImageWriterCommand>& commands,
           uword* entry_point) {
+#if defined(TARGET_ARCH_MIPS)
+        // On MIPS the trampoline is generated within the caller’s code.
+        EXPECT_EQ(6, commands.length());
+#else
         EXPECT_EQ(7, commands.length());
+#endif
 
         // This is the backwards call target.
         EXPECT_EQ(ImageWriterCommand::InsertInstructionOfCode, commands[0].op);
@@ -428,8 +445,13 @@ ISOLATE_UNIT_TEST_CASE(CodeRelocator_OutOfRangeBackwardCall) {
         // This is the last change the relocator thinks it can ensure the
         // out-of-range call above can call a trampoline - so it injets it here
         // and no later.
+#if defined(TARGET_ARCH_MIPS)
+        // On MIPS the trampoline is generated within the caller’s code.
+        EXPECT_EQ(ImageWriterCommand::InsertInstructionOfCode, commands[5].op);
+#else
         EXPECT_EQ(ImageWriterCommand::InsertBytesOfTrampoline, commands[5].op);
         EXPECT_EQ(ImageWriterCommand::InsertInstructionOfCode, commands[6].op);
+#endif
 
         *entry_point = commands[2].expected_offset;
       });
@@ -443,7 +465,7 @@ ISOLATE_UNIT_TEST_CASE(CodeRelocator_OutOfRangeBackwardCall2) {
 #if defined(TARGET_ARCH_MIPS)
       12,                                    // backwards call target
       bmax - 12 - helper.kOffsetOfCall + 4,  // 4 bytes exceeding backwards range
-      36,  // caller (call instruction @helper.kOffsetOfCall)
+      64,  // caller (call instruction @helper.kOffsetOfCall)
       4,
 #else
       8,                                    // backwards call target
@@ -457,7 +479,12 @@ ISOLATE_UNIT_TEST_CASE(CodeRelocator_OutOfRangeBackwardCall2) {
   helper.BuildImageAndRunTest(
       [&](const GrowableArray<ImageWriterCommand>& commands,
           uword* entry_point) {
+#if defined(TARGET_ARCH_MIPS)
+        // On MIPS the trampoline is generated within the caller’s code.
+        EXPECT_EQ(4, commands.length());
+#else
         EXPECT_EQ(5, commands.length());
+#endif
 
         // This is the backwards call target.
         EXPECT_EQ(ImageWriterCommand::InsertInstructionOfCode, commands[0].op);
@@ -470,7 +497,9 @@ ISOLATE_UNIT_TEST_CASE(CodeRelocator_OutOfRangeBackwardCall2) {
         EXPECT_EQ(ImageWriterCommand::InsertInstructionOfCode, commands[3].op);
         // There's no other instructions coming, so the relocator will resolve
         // any pending out-of-range calls by inserting trampolines at the end.
+#if !defined(TARGET_ARCH_MIPS)
         EXPECT_EQ(ImageWriterCommand::InsertBytesOfTrampoline, commands[4].op);
+#endif
 
         *entry_point = commands[4].expected_offset;
       });

--- a/runtime/vm/instructions_mips.cc
+++ b/runtime/vm/instructions_mips.cc
@@ -324,23 +324,17 @@ void PcRelativeTrampolineJumpPattern::Initialize() {
       reinterpret_cast<uint32_t*>(pattern_start_ + 2 * Instr::kInstrSize);
   uint32_t* branch_and_link =
       reinterpret_cast<uint32_t*>(pattern_start_ + 3 * Instr::kInstrSize);
-  uint32_t* nop_first =
-      reinterpret_cast<uint32_t*>(pattern_start_ + 4 * Instr::kInstrSize);
   uint32_t* add_RA_TMP =
-      reinterpret_cast<uint32_t*>(pattern_start_ + 5 * Instr::kInstrSize);
+      reinterpret_cast<uint32_t*>(pattern_start_ + 4 * Instr::kInstrSize);
+  uint32_t* jump_register =
+       reinterpret_cast<uint32_t*>(pattern_start_ + 5 * Instr::kInstrSize);
   uint32_t* load_RA =
       reinterpret_cast<uint32_t*>(pattern_start_ + 6 * Instr::kInstrSize);
-  uint32_t* jump_register =
-      reinterpret_cast<uint32_t*>(pattern_start_ + 7 * Instr::kInstrSize);
-  uint32_t* nop_second =
-      reinterpret_cast<uint32_t*>(pattern_start_ + 8 * Instr::kInstrSize);
   *store_RA = kStoreRA;
   *branch_and_link = kBranchAndLinkEncoding;
-  *nop_first = Instr::kNopInstruction;
   *add_RA_TMP = kAddRaTmpEncoding;
-  *load_RA = kLoadRA;
   *jump_register = kJumpRegisterEncoding;
-  *nop_second = Instr::kNopInstruction;
+  *load_RA = kLoadRA;
   set_distance(0);
 #else
   UNREACHABLE();
@@ -387,24 +381,18 @@ bool PcRelativeTrampolineJumpPattern::IsValid() const {
       reinterpret_cast<uint32_t*>(pattern_start_ + 2 * Instr::kInstrSize);
   uint32_t* branch_and_link =
       reinterpret_cast<uint32_t*>(pattern_start_ + 3 * Instr::kInstrSize);
-  uint32_t* nop_first =
-      reinterpret_cast<uint32_t*>(pattern_start_ + 4 * Instr::kInstrSize);
   uint32_t* add_RA_TMP =
+      reinterpret_cast<uint32_t*>(pattern_start_ + 4 * Instr::kInstrSize);
+  uint32_t* jump_register =
       reinterpret_cast<uint32_t*>(pattern_start_ + 5 * Instr::kInstrSize);
   uint32_t* load_RA =
       reinterpret_cast<uint32_t*>(pattern_start_ + 6 * Instr::kInstrSize);
-  uint32_t* jump_register =
-      reinterpret_cast<uint32_t*>(pattern_start_ + 7 * Instr::kInstrSize);
-  uint32_t* nop_second =
-      reinterpret_cast<uint32_t*>(pattern_start_ + 8 * Instr::kInstrSize);
 
   if (*store_RA != kStoreRA) return false;
   if (*branch_and_link != kBranchAndLinkEncoding) return false;
-  if (*nop_first != Instr::kNopInstruction) return false;
   if (*add_RA_TMP != kAddRaTmpEncoding) return false;
-  if (*load_RA != kLoadRA) return false;
   if (*jump_register != kJumpRegisterEncoding) return false;
-  if (*nop_second != Instr::kNopInstruction) return false;
+  if (*load_RA != kLoadRA) return false;
 
   return true;
 #else
@@ -421,8 +409,9 @@ intptr_t TypeTestingStubCallPattern::GetSubtypeTestCachePoolIndex() {
   // pc_ = next inst to exe
   uword pc = pc_ - 2 * Instr::kInstrSize;
   //jalr RA, S2(=R18)
-  const uint32_t jalr_t9 = 0x0240f809;
-  if(*reinterpret_cast<uint32_t*>(pc) != jalr_t9) {
+  const uint32_t jalr_S2 = 0x0240f809;
+  if(*reinterpret_cast<uint32_t*>(pc) != jalr_S2) {
+    pc = pc - 7 * Instr::kInstrSize;
     PcRelativeCallPattern pattern(pc);
     RELEASE_ASSERT(pattern.IsValid());
   }

--- a/runtime/vm/instructions_mips.h
+++ b/runtime/vm/instructions_mips.h
@@ -183,7 +183,7 @@ class PcRelativePatternBase : public ValueObject {
 
   explicit PcRelativePatternBase(uword pc) : pc_(pc) {}
 
-  static constexpr int kLengthInBytes = 2 * Instr::kInstrSize;
+  static constexpr int kLengthInBytes = 9 * Instr::kInstrSize;
 
   int32_t distance() {
 #if !defined(DART_PRECOMPILED_RUNTIME)
@@ -222,6 +222,15 @@ class PcRelativeTailCallPattern : public PcRelativePatternBase {
   bool IsValid() const;
 };
 
+// The pattern of the trampoline looks like:
+//        lui TMP, #upper_16
+//        ori TMP, TMP, #lower_16
+//        sw RA, -4(SP)
+//        bal(label)
+//        add TMP, RA, TMP - delay slot, new return address is in RA register
+// label: jr(TMP)              
+//        lw RA, -4(SP)    - delay slot
+
 class PcRelativeTrampolineJumpPattern : public ValueObject {
  public:
   explicit PcRelativeTrampolineJumpPattern(uword pattern_start)
@@ -229,7 +238,7 @@ class PcRelativeTrampolineJumpPattern : public ValueObject {
     USE(pattern_start_);
   }
 
-  static constexpr int kLengthInBytes = 9 * Instr::kInstrSize;
+  static constexpr int kLengthInBytes = 7 * Instr::kInstrSize;
 
   void Initialize();
 


### PR DESCRIPTION
The changes apply to the MIPS architecture and address how trampolines for long branches are generated. The issue occurred during the relocation phase, where executable code was written into the file, while the trampoline was appended to the end of the .text section at the moment it was deemed necessary.
On MIPS, a branch instruction can only reach a limited range (effectively 18 bits with 4-byte alignment, using a 16-bit offset). The problem arises when the trampoline is generated at a location that the branch cannot reach.
The solution introduces additional space wherever code is generated from GenerateUnRelocatedPcRelativeTailCall and GenerateUnRelocatedPcRelativeCall, ensuring that trampolines are placed within this space so they remain reachable by branch instructions.
Tests in relocation_test.cc have been updated to reflect the new behavior.