### PR TITLE
[mips] Enable AOT test support via QEMU and toolchain config

### DIFF
--- a/pkg/test_runner/lib/src/compiler_configuration.dart
+++ b/pkg/test_runner/lib/src/compiler_configuration.dart
@@ -1053,6 +1053,8 @@ class PrecompilerCompilerConfiguration extends CompilerConfiguration
         cc = 'riscv32-linux-gnu-gcc';
       } else if (_isSimRiscv64 || (_isRiscv64 && _configuration.useQemu)) {
         cc = 'riscv64-linux-gnu-gcc';
+      } else if (_isSimMips || (_isMips && _configuration.useQemu)) {
+        cc = 'mipsel-linux-gnu-gcc';
       } else {
         cc = 'gcc';
       }

--- a/pkg/test_runner/lib/src/runtime_configuration.dart
+++ b/pkg/test_runner/lib/src/runtime_configuration.dart
@@ -303,7 +303,8 @@ enum QemuConfig {
   arm._('qemu-arm', '/usr/arm-linux-gnueabihf/'),
   arm64._('qemu-aarch64', '/usr/aarch64-linux-gnu/'),
   riscv32._('qemu-riscv32', '/usr/riscv32-linux-gnu/'),
-  riscv64._('qemu-riscv64', '/usr/riscv64-linux-gnu/');
+  riscv64._('qemu-riscv64', '/usr/riscv64-linux-gnu/'),
+  mips._('qemu-mipsel', '/usr/mipsel-linux-gnu/');
 
   static const all = <Architecture, QemuConfig>{
     Architecture.ia32: QemuConfig.ia32,
@@ -315,6 +316,7 @@ enum QemuConfig {
     Architecture.arm64c: QemuConfig.arm64,
     Architecture.riscv32: QemuConfig.riscv32,
     Architecture.riscv64: QemuConfig.riscv64,
+    Architecture.mips: QemuConfig.mips,
   };
 
   final String executable;


### PR DESCRIPTION
This PR adds initial support for running AOT tests on MIPS targets
using QEMU in the Dart test runner.