### PR TITLE
[mips] Use syscall cacheflush for ICache flush

### DIFF
--- a/runtime/vm/cpu_mips.cc
+++ b/runtime/vm/cpu_mips.cc
@@ -28,9 +28,7 @@ void CPU::FlushICache(uword start, uword size) {
   }
 
 #if defined(DART_HOST_OS_LINUX)
-  char* beg = reinterpret_cast<char*>(start);
-  char* end = reinterpret_cast<char*>(start + size);
-  __builtin___clear_cache(beg, end);
+  syscall(__NR_cacheflush, start, size, ICACHE);
 #else
 #error FlushICache only tested/supported on Linux
 #endif


### PR DESCRIPTION
Replace __builtin___clear_cache with a direct syscall to __NR_cacheflush in CPU::FlushICache on Linux.
The previous implementation was closer to the approach used on RISC-V and ARM, but it caused issues when running code on the target board. These problems were not observed with the syscall-based implementation, which proved to be more reliable in this environment.
