### PR TITLE
[mips] Use word-sized atomics for profiler counters.

### DIFF
--- a/runtime/vm/profiler.h
+++ b/runtime/vm/profiler.h
@@ -52,7 +52,19 @@ class SampleBlock;
   V(sample_allocation_failure)
 
 struct ProfilerCounters {
-#define DECLARE_PROFILER_COUNTER(name) RelaxedAtomic<int64_t> name;
+#if defined(TARGET_ARCH_MIPS)
+  // TODO(mips):
+  // Revisit use of atomic operations in signal handlers.
+  // 64-bit atomics (e.g. RelaxedAtomic<int64_t>) may call into libatomic
+  // (__atomic_fetch_add_8) on some targets (e.g. MIPS32), which is not
+  // async-signal-safe and can deadlock if it takes a lock.
+  // Ensure all operations in signal handlers are lock-free and
+  // async-signal-safe, or move them out of the handler.
+  using ProfilerCounter = intptr_t;
+#else
+  using ProfilerCounter = int64_t;
+#endif
+#define DECLARE_PROFILER_COUNTER(name) RelaxedAtomic<ProfilerCounter> name;
   PROFILER_COUNTERS(DECLARE_PROFILER_COUNTER)
 #undef DECLARE_PROFILER_COUNTER
 };


### PR DESCRIPTION
This PR changes profiler diagnostic counters from `RelaxedAtomic<int64_t>` to word-sized atomics (`RelaxedAtomic<intptr_t>`). 

On MIPS32, 64-bit atomic increments are not emitted as inline lock-free operations. They are lowered to `__atomic_fetch_add_8` from `libatomic`, which uses locking internally. Some profiler counters are updated from `Profiler::SampleThread()`, which can run inside the `SIGPROF` handler. Calling a helper that takes a lock from a signal handler is not signal-safe and can deadlock the interrupted thread.

The hang happened while `LoadTestScript()` was waiting for the kernel isolate compile response. With the profiler enabled, `SIGPROF` could interrupt the worker thread, and on MIPS32 the signal handler sampling path could get stuck while updating one of these 64-bit counters. As a result, compile response was never delivered.

Using `intptr_t` keeps these counter updates word-sized on MIPS32, allowing the compiler to emit inline atomic operations instead of calling the 64-bit `libatomic` helper. With this change, all profiler tests now pass on MIPS.